### PR TITLE
Config: Introduce OPA_DECISION_LOG_UPLOAD_SIZE_LIMIT envar

### DIFF
--- a/horizon/config.py
+++ b/horizon/config.py
@@ -93,6 +93,11 @@ class SidecarConfig(Confi):
         10,
         description="max amount of time (in seconds) to wait between decision log uploads",
     )
+    OPA_DECISION_LOG_UPLOAD_SIZE_LIMIT = confi.int(
+        "OPA_DECISION_LOG_UPLOAD_SIZE_LIMIT",
+        32768,
+        description="log upload size limit in bytes. OPA will chunk uploads to cap message body to this limit",
+    )
 
     # temp log format (until cloud config is received)
     TEMP_LOG_FORMAT = confi.str(

--- a/horizon/enforcer/opa/config_maker.py
+++ b/horizon/enforcer/opa/config_maker.py
@@ -55,6 +55,7 @@ def get_opa_config_file_path(
             log_ingress_endpoint=sidecar_config.OPA_DECISION_LOG_INGRESS_ROUTE,
             min_delay_seconds=sidecar_config.OPA_DECISION_LOG_MIN_DELAY,
             max_delay_seconds=sidecar_config.OPA_DECISION_LOG_MAX_DELAY,
+            upload_size_limit_bytes=sidecar_config.OPA_DECISION_LOG_UPLOAD_SIZE_LIMIT,
             log_to_console=sidecar_config.OPA_DECISION_LOG_CONSOLE,
         )
     except jinja2.TemplateNotFound:

--- a/horizon/static/templates/config.yaml.template
+++ b/horizon/static/templates/config.yaml.template
@@ -16,3 +16,4 @@ decision_logs:
   reporting:
     min_delay_seconds: {{ min_delay_seconds }}
     max_delay_seconds: {{ max_delay_seconds }}
+    upload_size_limit_bytes: {{ upload_size_limit_bytes }}


### PR DESCRIPTION
The default is 32kb like OPA's default.
If increased - this helps eliminate the error msg: `log encoding failed: upload chunk size exceeds upload_size_limit_bytes` (if the limit is high enough)