### PR TITLE
feat: set uid and gid in Dockerfile to 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ FROM python-base
 
 WORKDIR /app
 
-RUN addgroup -S permit -g 1000
+RUN addgroup -S permit -g 999
 RUN adduser -S -s /bin/bash -u 1000 -G permit -h /home/permit permit
 
 # copy libraries from build stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ FROM python-base
 
 WORKDIR /app
 
-RUN addgroup -S permit
-RUN adduser -S -s /bin/bash -G permit -h /home/permit permit
+RUN addgroup -S permit -g 1000
+RUN adduser -S -s /bin/bash -u 1000 -G permit -h /home/permit permit
 
 # copy libraries from build stage
 RUN mkdir /home/permit/.local


### PR DESCRIPTION
If you have the gatekeeper policy `NSA CISA Kubernetes Hardening v1.2 policy bundle constraints` in your kubernetes cluster, it will complain that the permit-pdp image UID and GID are not above 1000 (it's a questionable constraint).
In the older Debian based pdp-v2 image, UID and GID were set to 1000 and 999 respectively.
This PR sets them both to 1000.

