### PR TITLE
roe/per-9551 Introduce offline mode to PDP (to compliment OPAL's offline mode)

### DIFF
--- a/horizon/config.py
+++ b/horizon/config.py
@@ -2,6 +2,7 @@ from opal_common.confi import Confi, confi
 
 MOCK_API_KEY = "MUST BE DEFINED"
 
+
 # scopes enum
 class ApiKeyLevel(str):
     ORGANIZATION = "organization"
@@ -113,6 +114,12 @@ class SidecarConfig(Confi):
         "OFFLINE_MODE_BACKUP_PATH",
         "/app/backup/sidecar_config.json",
         description="Path to backup sidecar cloud configuration to when in offline mode",
+    )
+
+    CONFIG_FETCH_MAX_RETRIES = confi.int(
+        "CONFIG_FETCH_MAX_RETRIES",
+        6,
+        description="Number of times to retry fetching the sidecar configuration from control plane",
     )
 
     # centralized logging

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -111,7 +111,7 @@ class SidecarConfig(Confi):
 
     OFFLINE_MODE_BACKUP_PATH = confi.str(
         "OFFLINE_MODE_BACKUP_PATH",
-        "./permit_pdp_config_backup",  # TODO: Fix this path
+        "/app/backup/sidecar_config.json",
         description="Path to backup sidecar cloud configuration to when in offline mode",
     )
 

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -110,10 +110,15 @@ class SidecarConfig(Confi):
         description="if true, sidecar will use a file backup to restore configuration and policy data when cloud services are unavailable",
     )
 
-    OFFLINE_MODE_BACKUP_PATH = confi.str(
-        "OFFLINE_MODE_BACKUP_PATH",
-        "/app/backup/sidecar_config.json",
-        description="Path to backup sidecar cloud configuration to when in offline mode",
+    OFFLINE_MODE_BACKUP_DIR = confi.str(
+        "OFFLINE_MODE_BACKUP_DIR",
+        "/app/backup",
+        description="Dir path where pdp would backup its cloud configuration when in offline mode",
+    )
+    OFFLINE_MODE_BACKUP_FILENAME = confi.str(
+        "OFFLINE_MODE_BACKUP_FILENAME",
+        "pdp_cloud_config_backup.json",
+        description="Filename for offline mode's cloud configuration backup",
     )
 
     CONFIG_FETCH_MAX_RETRIES = confi.int(

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -103,6 +103,18 @@ class SidecarConfig(Confi):
     # enable datadog APM tracing
     ENABLE_MONITORING = confi.bool("ENABLE_MONITORING", False)
 
+    ENABLE_OFFLINE_MODE = confi.bool(
+        "ENABLE_OFFLINE_MODE",
+        False,
+        description="if true, sidecar will use a file backup to restore configuration and policy data when cloud services are unavailable",
+    )
+
+    OFFLINE_MODE_BACKUP_PATH = confi.str(
+        "OFFLINE_MODE_BACKUP_PATH",
+        "./permit_pdp_config_backup",  # TODO: Fix this path
+        description="Path to backup sidecar cloud configuration to when in offline mode",
+    )
+
     # centralized logging
     CENTRAL_LOG_DRAIN_URL = confi.str(
         "CENTRAL_LOG_DRAIN_URL", "https://listener.logz.io:8071"

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -99,14 +99,14 @@ class PermitPDP:
             raise SystemExit(GUNICORN_EXIT_APP)
 
         if not remote_config:
-            logger.warning(
-                "Could not fetch config from cloud control plane, reverting to local config!"
-            )
-        else:
-            logger.info("Applying config overrides from cloud control plane...")
-            apply_config(remote_config.opal_common or {}, opal_common_config)
-            apply_config(remote_config.opal_client or {}, opal_client_config)
-            apply_config(remote_config.pdp or {}, sidecar_config)
+            logger.critical("No cloud configuration found. Exiting.")
+            raise SystemExit(GUNICORN_EXIT_APP)
+
+        logger.info("Applying config overrides from cloud control plane...")
+
+        apply_config(remote_config.opal_common or {}, opal_common_config)
+        apply_config(remote_config.opal_client or {}, opal_client_config)
+        apply_config(remote_config.pdp or {}, sidecar_config)
 
         self._log_environment(remote_config.context)
 

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -22,7 +22,7 @@ from opal_common.logging.formatter import Formatter
 
 from horizon.facts.router import facts_router
 from horizon.authentication import enforce_pdp_token
-from horizon.config import MOCK_API_KEY, sidecar_config, ApiKeyLevel
+from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.enforcer.api import init_enforcer_api_router, stats_manager
 from horizon.enforcer.opa.config_maker import (
     get_opa_authz_policy_file_path,
@@ -118,6 +118,7 @@ class PermitPDP:
             self._configure_inline_opa_config()
 
         self._configure_opal_data_updater()
+        self._configure_opal_offline_mode()
 
         if sidecar_config.PRINT_CONFIG_ON_STARTUP:
             logger.info(
@@ -281,6 +282,16 @@ class PermitPDP:
             wait_strategy="random_exponential",
             attempts=14,
             wait_time=1,
+        )
+
+    def _configure_opal_offline_mode(self):
+        """
+        configure opal to use offline mode when enabled
+        """
+        opal_client_config.OFFLINE_MODE_ENABLED = sidecar_config.ENABLE_OFFLINE_MODE
+        opal_client_config.STORE_BACKUP_PATH = os.path.join(
+            os.path.dirname(sidecar_config.OFFLINE_MODE_BACKUP_PATH),
+            "policy_store_data.json",
         )
 
     def _fix_data_topics(self) -> List[str]:

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -290,8 +290,8 @@ class PermitPDP:
         """
         opal_client_config.OFFLINE_MODE_ENABLED = sidecar_config.ENABLE_OFFLINE_MODE
         opal_client_config.STORE_BACKUP_PATH = os.path.join(
-            os.path.dirname(sidecar_config.OFFLINE_MODE_BACKUP_PATH),
-            "policy_store_data.json",
+            sidecar_config.OFFLINE_MODE_BACKUP_DIR,
+            "policy_store_backup.json",
         )
 
     def _fix_data_topics(self) -> List[str]:

--- a/horizon/startup/offline_mode.py
+++ b/horizon/startup/offline_mode.py
@@ -1,0 +1,86 @@
+from typing import Optional, Tuple
+
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.backends import default_backend
+from cryptography.fernet import Fernet
+from pydantic import ValidationError
+import base64
+import secrets
+
+from horizon.startup.schemas import RemoteConfig, RemoteConfigBackup
+from opal_common.logger import logger
+
+
+class OfflineModeManager:
+    """
+    A backup for the remote config, in case the sidecar can't fetch the remote config.
+    """
+
+    def __init__(self, backup_path: str, api_key: str):
+        self._backup_path: str = backup_path
+        self._api_key = api_key
+
+    def _derive_backup_key(self, salt: Optional[bytes] = None) -> Tuple[bytes, bytes]:
+        if salt is None:
+            salt = secrets.token_bytes(16)
+        else:
+            salt = base64.urlsafe_b64decode(salt)
+
+        hkdf = HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            info=b"Sidecar's local remote-config backup Key",
+            backend=default_backend(),
+        )
+        # We don't bother extracting the actual cryptographic bytes from the API key (which has a urlsafe encoding + a prefix),
+        # The 512-bit entropy is still there, and HKDF's extract phase handles inputs of non-uniform randomness.
+        key_bytes = hkdf.derive(self._api_key.encode("utf-8"))
+        return base64.urlsafe_b64encode(key_bytes), base64.urlsafe_b64encode(salt)
+
+    def backup_config(self, remote_config: RemoteConfig):
+        # TODO: Don't use backup when remote config fetching fails due to an error which isn't a network error
+        # TODO: Configure OPAL to use offline mode as well
+        # TODO: Opal backup should be encrypted as well
+        # TODO: Use a resaonable retry policy for fetching, should be configurable, should exit PDP if everything fails
+        # TODO: Atomic writing the backup file
+
+        logger.info(
+            "Backing up remote config to {path}",
+            path=self._backup_path,
+        )
+
+        enc_key, salt = self._derive_backup_key()
+
+        with open(self._backup_path, "w") as f:
+            f.write(
+                RemoteConfigBackup(
+                    enc_remote_config=Fernet(enc_key).encrypt(
+                        remote_config.json(ensure_ascii=False).encode()
+                    ),
+                    key_derivation_salt=salt,
+                ).json(ensure_ascii=False)
+            )
+        # TODO: Handle exceptions
+
+    def restore_config(self) -> Optional[RemoteConfig]:
+        logger.info(
+            "Loading config from local backup at {path}",
+            path=self._backup_path,
+        )
+        remote_config_backup: RemoteConfigBackup
+        try:
+            with open(self._backup_path, "r") as f:
+                remote_config_backup = RemoteConfigBackup.parse_raw(f.read())
+        except FileNotFoundError:
+            logger.warning("Local backup file of sidecar config not found")
+            return None
+        except ValidationError:
+            logger.error("Failed to parse backup remote config")
+            return None
+
+        dec_key, _ = self._derive_backup_key(remote_config_backup.key_derivation_salt)
+        return RemoteConfig.parse_raw(
+            Fernet(dec_key).decrypt(remote_config_backup.enc_remote_config)
+        )

--- a/horizon/startup/offline_mode.py
+++ b/horizon/startup/offline_mode.py
@@ -7,6 +7,7 @@ from cryptography.fernet import Fernet
 from pydantic import ValidationError
 import base64
 import secrets
+import os
 
 from horizon.startup.schemas import RemoteConfig, RemoteConfigBackup
 from opal_common.logger import logger
@@ -46,7 +47,7 @@ class OfflineModeManager:
         )
 
         enc_key, salt = self._derive_backup_key()
-
+        os.makedirs(os.path.dirname(self._backup_path), exist_ok=True)
         try:
             with open(self._backup_path, "w") as f:
                 f.write(

--- a/horizon/startup/offline_mode.py
+++ b/horizon/startup/offline_mode.py
@@ -84,3 +84,16 @@ class OfflineModeManager:
         return RemoteConfig.parse_raw(
             Fernet(dec_key).decrypt(remote_config_backup.enc_remote_config)
         )
+
+    def process_remote_config(
+        self, remote_config: Optional[RemoteConfig]
+    ) -> Optional[RemoteConfig]:
+        if remote_config is None:
+            # Cloud fetch failed, try to restore from backup
+            remote_config = self.restore_config()
+        else:
+            # Cloud fetch succeeded, backup the fetched config
+            self.backup_config(remote_config)
+
+        # We handle enabling OPAL's offline mode in pdp.py
+        return remote_config

--- a/horizon/startup/offline_mode.py
+++ b/horizon/startup/offline_mode.py
@@ -42,7 +42,6 @@ class OfflineModeManager:
     def backup_config(self, remote_config: RemoteConfig):
         # TODO: Don't use backup when remote config fetching fails due to an error which isn't a network error
         # TODO: Opal backup should be encrypted as well
-        # TODO: Use a resaonable retry policy for fetching, should be configurable, should exit PDP if everything fails
         # TODO: Atomic writing the backup file
 
         logger.info(

--- a/horizon/startup/offline_mode.py
+++ b/horizon/startup/offline_mode.py
@@ -41,7 +41,6 @@ class OfflineModeManager:
 
     def backup_config(self, remote_config: RemoteConfig):
         # TODO: Don't use backup when remote config fetching fails due to an error which isn't a network error
-        # TODO: Configure OPAL to use offline mode as well
         # TODO: Opal backup should be encrypted as well
         # TODO: Use a resaonable retry policy for fetching, should be configurable, should exit PDP if everything fails
         # TODO: Atomic writing the backup file

--- a/horizon/startup/remote_config.py
+++ b/horizon/startup/remote_config.py
@@ -40,8 +40,8 @@ class RemoteConfigFetcher:
 
     DEFAULT_RETRY_CONFIG = {
         "retry": retry_if_not_exception_type(NoRetryException),
-        "wait": wait.wait_random_exponential(max=10),
-        "stop": stop.stop_after_attempt(10),
+        "wait": wait.wait_random_exponential(max=5),
+        "stop": stop.stop_after_attempt(6),
         "reraise": True,
     }
 

--- a/horizon/startup/remote_config.py
+++ b/horizon/startup/remote_config.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import os.path
 import requests
 from opal_common.logger import logger
 from pydantic import ValidationError
@@ -128,7 +129,11 @@ def get_remote_config():
 
     if sidecar_config.ENABLE_OFFLINE_MODE:
         offline_mode = OfflineModeManager(
-            sidecar_config.OFFLINE_MODE_BACKUP_PATH, get_env_api_key()
+            os.path.join(
+                sidecar_config.OFFLINE_MODE_BACKUP_DIR,
+                sidecar_config.OFFLINE_MODE_BACKUP_FILENAME,
+            ),
+            get_env_api_key(),
         )
         _remote_config = offline_mode.process_remote_config(_remote_config)
 

--- a/horizon/startup/remote_config.py
+++ b/horizon/startup/remote_config.py
@@ -78,7 +78,7 @@ class RemoteConfigFetcher:
         try:
             return fetch_with_retry()
         except requests.RequestException:
-            logger.warning("Failed to get PDP config")
+            logger.warning("Failed to get PDP config from control plane")
             return None
 
     def _fetch_config(self) -> RemoteConfig:
@@ -130,9 +130,6 @@ def get_remote_config():
         offline_mode = OfflineModeManager(
             sidecar_config.OFFLINE_MODE_BACKUP_PATH, get_env_api_key()
         )
-        if _remote_config is None:
-            _remote_config = offline_mode.restore_config()
-        else:
-            offline_mode.backup_config(_remote_config)
+        _remote_config = offline_mode.process_remote_config(_remote_config)
 
     return _remote_config

--- a/horizon/startup/remote_config.py
+++ b/horizon/startup/remote_config.py
@@ -41,7 +41,7 @@ class RemoteConfigFetcher:
     DEFAULT_RETRY_CONFIG = {
         "retry": retry_if_not_exception_type(NoRetryException),
         "wait": wait.wait_random_exponential(max=5),
-        "stop": stop.stop_after_attempt(6),
+        "stop": stop.stop_after_attempt(sidecar_config.CONFIG_FETCH_MAX_RETRIES),
         "reraise": True,
     }
 

--- a/horizon/startup/schemas.py
+++ b/horizon/startup/schemas.py
@@ -6,3 +6,12 @@ class RemoteConfig(BaseModel):
     opal_client: dict = {}
     pdp: dict = {}
     context: dict = {}
+
+
+class RemoteConfigBackup(BaseModel):
+    """
+    A backup for the remote config, in case the sidecar can't fetch the remote config.
+    """
+
+    enc_remote_config: bytes
+    key_derivation_salt: bytes


### PR DESCRIPTION
When enabled:
* Remote config would be stored to disk after fetched from cloud.
* Config backup file would be read if fetching failed.
* OPAL's offline mode would be auto-enabled and its backup file's path configured.

When enabled or disabled:
* Default fetching retry parameters are tuned down a bit (max 5s instead of 10s, max 6 retries instead of 10) - so offline mode would take over sooner (when no offline mode, container gonna be restarted anyway on failure)
* Max retries are configurable.