### PR TITLE
Remove httpx from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 pytest
 aioresponses
-httpx
 pytest-asyncio
 aiohttp>=3.9.4,<4


### PR DESCRIPTION
It was installed in CI as 0.27.2, only then was regular requirements.txt installed and httpx 0.27.2 conflicted with opal's httpx 0.27.0