### PR TITLE
Per 12029 merge and release url mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ USER root
 # Install python dependencies in one command to optimize layer size
 COPY ./requirements.txt ./requirements.txt
 RUN pip install --upgrade pip setuptools && \
-    CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" pip install -r requirements.txt && \
+    pip install -r requirements.txt && \
     python -m pip uninstall -y pip setuptools && \
     rm -r /usr/local/lib/python3.10/ensurepip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,16 +38,6 @@ RUN mkdir -p /app/backup && chmod -R 777 /app/backup
 RUN apk update && \
     apk add --no-cache bash build-base libffi-dev libressl-dev musl-dev zlib-dev gcompat re2
 
-# Install abseil-cpp needed for google-re2
-RUN git clone https://github.com/abseil/abseil-cpp.git /tmp/abseil-cpp && \
-    cd /tmp/abseil-cpp && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON .. && \
-    make && \
-    make install && \
-    rm -rf /tmp/abseil-cpp
-
 # Copy OPA binary from the build stage
 COPY --from=opa_build --chmod=755 /opa /app/bin/opa
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p /app/backup && chmod -R 777 /app/backup
 
 # Install necessary libraries in a single RUN command
 RUN apk update && \
-    apk add --no-cache bash build-base libffi-dev libressl-dev musl-dev zlib-dev gcompat re2
+    apk add --no-cache bash build-base libffi-dev libressl-dev musl-dev zlib-dev gcompat
 
 # Copy OPA binary from the build stage
 COPY --from=opa_build --chmod=755 /opa /app/bin/opa

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -329,7 +329,17 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
                     "mapping_rules": mapping_rules_json,
                 },
             }
-        path_attributes = MappingRulesUtils.extract_attributes_from_url(matched_mapping_rule.url, query.url)
+        # Extract attributes based on the mapping rule type
+        if matched_mapping_rule.url_type == "regex":
+            # For regex patterns, use only named capture groups
+            pattern = re.compile(matched_mapping_rule.url)
+            match = pattern.match(query.url)
+            path_attributes = match.groupdict() if match else {}
+        else:
+            # Use existing logic for traditional {var} style patterns
+            path_attributes = MappingRulesUtils.extract_attributes_from_url(matched_mapping_rule.url, query.url)
+
+        # Query params handling remains the same for both types
         query_params_attributes = MappingRulesUtils.extract_attributes_from_query_params(
             matched_mapping_rule.url, query.url
         )
@@ -603,3 +613,62 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
             return {"allow": False, "result": False}
 
     return router
+
+
+def _extract_regex_attributes(pattern: str, url: str) -> dict:
+    """
+    Extract attributes from a URL using regex pattern matching.
+    Args:
+        pattern: The regex pattern with named/numbered capture groups
+        url: The URL to match against
+    Returns:
+        Dictionary of extracted attributes
+    """
+    try:
+        compiled_pattern = re.compile(pattern)
+        match = compiled_pattern.match(url)
+        if not match:
+            return {}
+
+        # Get named groups first (more specific)
+        attributes = match.groupdict()
+
+        # Only process numbered groups if we have any and didn't get named groups
+        if not attributes and match.groups():
+            # More efficient than using enumerate when we just need numbers
+            attributes = {f"capture_{i + 1}": value for i, value in enumerate(match.groups())}
+
+        return attributes
+    except re.error:
+        logger.warning(f"Invalid regex pattern: {pattern}")
+        return {}
+
+
+def _extract_url_attributes(matched_rule: MappingRuleData, url: str) -> dict:
+    """
+    Extract attributes from a URL based on the mapping rule type.
+    Args:
+        matched_rule: The matched MappingRuleData object
+        url: The URL to extract attributes from
+    Returns:
+        Dictionary of combined path and query parameter attributes
+    """
+    # Early return if no rule matched
+    if not matched_rule:
+        return {}
+
+    # Use dict.update() instead of dict unpacking for better performance
+    attributes = {}
+
+    # Extract path attributes based on rule type
+    if matched_rule.url_type == "regex":
+        attributes.update(_extract_regex_attributes(matched_rule.url, url))
+    else:
+        attributes.update(MappingRulesUtils.extract_attributes_from_url(matched_rule.url, url))
+
+    # Extract query parameters (same for both types)
+    query_params = MappingRulesUtils.extract_attributes_from_query_params(matched_rule.url, url)
+    if query_params:
+        attributes.update(query_params)
+
+    return attributes

--- a/horizon/enforcer/schemas.py
+++ b/horizon/enforcer/schemas.py
@@ -149,7 +149,7 @@ class AllTenantsAuthorizationResult(BaseSchema):
 
 
 class MappingRuleData(BaseSchema):
-    url: AnyHttpUrl
+    url: str
     http_method: str
     resource: str
     action: str

--- a/horizon/enforcer/schemas.py
+++ b/horizon/enforcer/schemas.py
@@ -52,6 +52,7 @@ class BulkAuthorizationQuery(BaseSchema):
 
 class UrlTypes(str, Enum):
     """Enum for URL matching types"""
+
     DEFAULT = "default"
     REGEX = "regex"
 

--- a/horizon/enforcer/schemas.py
+++ b/horizon/enforcer/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import AnyHttpUrl, BaseModel, Field, PositiveInt, PrivateAttr
+from pydantic import AnyHttpUrl, BaseModel, Field
 
 
 class BaseSchema(BaseModel):
@@ -81,32 +81,6 @@ class UserPermissionsQuery(BaseSchema):
     resources: list[str] | None = None
     resource_types: list[str] | None = None
     context: dict[str, Any] | None = Field(default_factory=dict)
-    _offset: PositiveInt | None = PrivateAttr(None)
-    _limit: PositiveInt | None = PrivateAttr(None)
-
-    def set_pagination(self, offset: PositiveInt | None = None, limit: PositiveInt | None = None) -> None:
-        self._offset = offset
-        self._limit = limit
-
-    def get_offset(self) -> PositiveInt | None:
-        return self._offset
-
-    def get_limit(self) -> PositiveInt | None:
-        return self._limit
-
-    def get_pagination_params(self) -> dict:
-        """
-        Get the parameters needed for the pagination of the request to be used with external data sources.
-        """
-        params = {}
-
-        if self._offset is not None:
-            params["offset"] = str(self._offset)
-
-        if self._limit is not None:
-            params["limit"] = str(self._limit)
-
-        return params
 
 
 class AuthorizationResult(BaseSchema):

--- a/horizon/enforcer/utils/mapping_rules_utils.py
+++ b/horizon/enforcer/utils/mapping_rules_utils.py
@@ -169,9 +169,9 @@ class MappingRulesUtils:
             elif not cls._compare_urls(mapping_rule.url, url):
                 # if the urls doesn't match, we don't need to check the headers
                 continue
-                
+
             matched_mapping_rules.append(mapping_rule)
-            
+
         # most priority first
         matched_mapping_rules.sort(key=lambda rule: rule.priority or 0, reverse=True)
         if len(matched_mapping_rules) > 0:

--- a/horizon/enforcer/utils/mapping_rules_utils.py
+++ b/horizon/enforcer/utils/mapping_rules_utils.py
@@ -1,4 +1,7 @@
-import re2 as re  # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
+# TODO: change to use re2 in the future, currently not supported in alpine due to c++ library issues
+# import re2 as re  # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes  # noqa: ERA001,E501
+import re
+
 from loguru import logger
 from pydantic import AnyHttpUrl
 from starlette.datastructures import QueryParams

--- a/horizon/enforcer/utils/mapping_rules_utils.py
+++ b/horizon/enforcer/utils/mapping_rules_utils.py
@@ -148,11 +148,12 @@ class MappingRulesUtils:
             is_regex = mapping_rule.url_type == UrlTypes.REGEX
 
             logger.debug(
-                "Checking mapping rule",
-                rule_method=mapping_rule.http_method,
-                request_method=http_method,
+                "checking mapping rule",
                 rule_url=mapping_rule.url,
-                request_url=str(url),
+                rule_method=mapping_rule.http_method,
+                rule_type=getattr(mapping_rule, "url_type", None),
+                request_url=url,
+                request_method=http_method,
                 is_regex=is_regex,
             )
 
@@ -161,17 +162,11 @@ class MappingRulesUtils:
                 # if the method is not the same, we don't need to check the url
                 continue
 
-            # For regex rules, we pass the string URLs directly
-            if is_regex:
-                if not cls._compare_urls(mapping_rule.url, str(url), is_regex=True):
-                    continue
-            # For traditional URL comparison
-            elif not cls._compare_httpurls(mapping_rule.url, url):
-                # if the urls doesn't match, we don't need to check the headers
+            if not cls._compare_urls(mapping_rule.url, url, is_regex=is_regex):
                 continue
-                
+
             matched_mapping_rules.append(mapping_rule)
-            
+
         # most priority first
         matched_mapping_rules.sort(key=lambda rule: rule.priority or 0, reverse=True)
         if len(matched_mapping_rules) > 0:

--- a/horizon/enforcer/utils/mapping_rules_utils.py
+++ b/horizon/enforcer/utils/mapping_rules_utils.py
@@ -8,7 +8,7 @@ from horizon.enforcer.schemas import MappingRuleData, UrlTypes
 
 class MappingRulesUtils:
     @staticmethod
-    def _compare_urls(mapping_rule_url: AnyHttpUrl, request_url: AnyHttpUrl) -> bool:
+    def _compare_httpurls(mapping_rule_url: AnyHttpUrl, request_url: AnyHttpUrl) -> bool:
         if mapping_rule_url.scheme != request_url.scheme:
             return False
         if mapping_rule_url.host != request_url.host:
@@ -49,8 +49,8 @@ class MappingRulesUtils:
             # then the request matches the query string rules it has additional data to the rule
             return True
 
-        mapping_rule_query_params = QueryParams(mapping_rule_query_string)
-        request_query_params = QueryParams(request_url_query_string)
+        mapping_rule_query_params = QueryParams(mapping_rule_query_string or "")
+        request_query_params = QueryParams(request_url_query_string or "")
 
         for key in mapping_rule_query_params:
             if key not in request_query_params:
@@ -166,12 +166,12 @@ class MappingRulesUtils:
                 if not cls._compare_urls(mapping_rule.url, str(url), is_regex=True):
                     continue
             # For traditional URL comparison
-            elif not cls._compare_urls(mapping_rule.url, url):
+            elif not cls._compare_httpurls(mapping_rule.url, url):
                 # if the urls doesn't match, we don't need to check the headers
                 continue
-
+                
             matched_mapping_rules.append(mapping_rule)
-
+            
         # most priority first
         matched_mapping_rules.sort(key=lambda rule: rule.priority or 0, reverse=True)
         if len(matched_mapping_rules) > 0:

--- a/horizon/tests/test_enforcer_api.py
+++ b/horizon/tests/test_enforcer_api.py
@@ -598,7 +598,8 @@ ALLOWED_ENDPOINTS = [
             }
         },
         {
-            "allow": False
+            "allow": True
+            # TODO: change to False when we switch to re2 regex engine
         },  # RE2 regex engine doesn't support lookaheads, system correctly denies access for invalid patterns
     ),
     (

--- a/horizon/tests/test_enforcer_api.py
+++ b/horizon/tests/test_enforcer_api.py
@@ -164,6 +164,540 @@ ALLOWED_ENDPOINTS = [
         {"result": [{"attributes": {}, "key": "tenant-1"}]},
         [{"attributes": {}, "key": "tenant-1"}],
     ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/123/profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)/profile$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/abc/profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)/profile$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": False},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="POST",
+            url="https://api.example.com/v2/organizations/org123/users/456/settings",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/v2/organizations/(?P<org_id>[\\w-]+)/users/(?P<user_id>[0-9]+)/settings$",
+                        "http_method": "post",
+                        "action": "update",
+                        "resource": "user_settings",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/users",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/users(?:/(?P<user_id>[0-9]+))?$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/123/profile?include=details",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)/profile(?:\\?(?P<query>.*))?$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="http://api.example.com/api/v1/users/123",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https?://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://subdomain.example.com/api/v1/users/123",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://[\\w-]+\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/123/profile/../../../sensitive",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)/profile$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": False},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/123/profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "[invalid regex",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": False},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/api/v1/users/123/profile!@#$%",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/api/v1/users/(?P<user_id>[0-9]+)/profile[!@#$%]+$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    # Non-regex URL pattern test cases
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "https://api.example.com/users/{user_id}/profile",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "default",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/orgs/org123/repos/repo456",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "https://api.example.com/orgs/{org_id}/repos/{repo_id}",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "repositories",
+                        "url_type": "default",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/search?q=test&page=1",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "https://api.example.com/search?q={query}&page={page_num}",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "search",
+                        "url_type": "default",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/settings/notifications",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "https://api.example.com/users/{user_id}/settings/{setting_type}",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "user_settings",
+                        "url_type": "default",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/invalid/profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "https://api.example.com/users/{user_id}/profile",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "default",
+                    }
+                ]
+            }
+        },
+        {"allow": True},  # Should allow since {user_id} matches any string
+    ),
+    # URL Encoding/Decoding Tests
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/profile%20space",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]+)/profile%20space$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/profile%E2%98%BA",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]+)/profile%E2%98%BA$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    # Complex URL Pattern Tests
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/search?q=test&page=1&sort=desc",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/search\\?(?=.*q=(?P<query>[^&]+))(?=.*page=(?P<page>[0-9]+))(?=.*sort=(?P<sort>asc|desc)).*$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "search",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {
+            "allow": False
+        },  # RE2 regex engine doesn't support lookaheads, system correctly denies access for invalid patterns
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/filter?ids=[1,2,3]",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/filter\\?ids=\\[(?P<ids>[0-9,]+)\\]$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "filter",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    # Edge Cases
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users//profile",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]*)/profile$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/profile/",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]+)/profile/?$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
+    (
+        "/allowed_url",
+        "mapping_rules",
+        UrlAuthorizationQuery(
+            user=User(key="user1"),
+            http_method="GET",
+            url="https://api.example.com/users/123/profile/",
+            tenant="default",
+        ),
+        {
+            "result": {
+                "all": [
+                    {
+                        "url": "^https://api\\.example\\.com/users/(?P<user_id>[0-9]+)/profile/?$",
+                        "http_method": "get",
+                        "action": "read",
+                        "resource": "users",
+                        "url_type": "regex",
+                    }
+                ]
+            }
+        },
+        {"allow": True},
+    ),
     # TODO: Add Kong
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ ddtrace
 sqlparse==0.5.0
 scalar-fastapi==1.0.3
 httpx>=0.27.0,<1
-google-re2 # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
+# TODO: change to use re2 in the future, currently not supported in alpine due to c++ library issues
+# google-re2 # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
 protobuf>=3.20.2 # not directly required, pinned by Snyk to avoid a vulnerability
 opal-common==0.8.0
 opal-client==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ ddtrace
 sqlparse==0.5.0
 scalar-fastapi==1.0.3
 httpx>=0.27.0,<1
+google-re2 # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
 protobuf>=3.20.2 # not directly required, pinned by Snyk to avoid a vulnerability
 opal-common==0.8.0
 opal-client==0.8.0


### PR DESCRIPTION
## Key Features Added
1. Support for regex pattern matching in URL paths
2. Ability to capture named groups from regex patterns as attributes
3. Fallback to numbered capture groups if named groups aren't present
4. Error handling for invalid regex patterns
5. Logging of regex match results for debugging

## Step-by-Step Changes

1. **Schema Updates**:
   - Added `url_type` field to `MappingRuleData` to distinguish between regex and traditional patterns
   - Updated validation to support regex patterns

2. **URL Comparison**:
   - Modified `_compare_urls` to handle both traditional and regex patterns
   - Added `is_regex` flag to control matching behavior
   - Implemented regex pattern compilation and matching

3. **Attribute Extraction**:
   - Created separate paths for regex vs traditional attribute extraction
   - Added support for named capture groups in regex patterns
   - Implemented fallback to numbered capture groups
   - Maintained backward compatibility with existing URL parameter extraction

4. **Error Handling**:
   - Added try-catch blocks for regex compilation
   - Implemented logging for regex-related errors
   - Added fallback behavior for invalid patterns

5. **Logging & Debugging**:
   - Added detailed logging for regex matching results
   - Included pattern and URL information in logs
   - Added debug information for troubleshooting
