### PR TITLE
Add caching support for PDP endpoints and implement related tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,10 @@ USER root
 COPY ./requirements.txt ./requirements.txt
 RUN pip install --upgrade pip setuptools && \
     pip install -r requirements.txt && \
+    # this is needed because there is a major bug in pendulum 3.0.0 that causes segfault in alpine linux
+    # and fastapi-cache2 depends on it, we couldn't write it in requirements.txt because
+    # it would cause a conflict with fastapi-cache that requres pendulum^3.0.0
+    pip install "pendulum<3.0.0" && \
     python -m pip uninstall -y pip setuptools && \
     rm -r /usr/local/lib/python3.10/ensurepip
 

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -257,6 +257,19 @@ class SidecarConfig(Confi):
         cast_from_json=parse_callbacks,
     )
 
+    # Cache configuration
+    PDP_CACHE_ENABLED = confi.bool(
+        "PDP_CACHE_ENABLED",
+        False,
+        description="If true, enables caching for specific PDP endpoints",
+    )
+
+    PDP_CACHE_TTL_SEC = confi.int(
+        "PDP_CACHE_TTL_SEC",
+        3600,  # 1 hour default
+        description="TTL for cached PDP responses in seconds",
+    )
+
     # non configurable values -------------------------------------------------
 
     # redoc configuration (openapi schema)

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -264,7 +264,7 @@ class SidecarConfig(Confi):
         description="If true, enables caching for specific PDP endpoints",
     )
 
-    PDP_CACHE_TTL_SEC = confi.int(
+    CACHE_TTL_SEC = confi.int(
         "CACHE_TTL_SEC",
         3600,  # 1 hour default
         description="TTL for cached PDP responses in seconds",

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -258,14 +258,14 @@ class SidecarConfig(Confi):
     )
 
     # Cache configuration
-    PDP_CACHE_ENABLED = confi.bool(
-        "PDP_CACHE_ENABLED",
+    CACHE_ENABLED = confi.bool(
+        "CACHE_ENABLED",
         False,
         description="If true, enables caching for specific PDP endpoints",
     )
 
     PDP_CACHE_TTL_SEC = confi.int(
-        "PDP_CACHE_TTL_SEC",
+        "CACHE_TTL_SEC",
         3600,  # 1 hour default
         description="TTL for cached PDP responses in seconds",
     )

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -13,7 +13,6 @@ import fastapi_cache.decorator
 import orjson
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi_cache import FastAPICache, default_key_builder
-from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.decorator import cache
 from opal_client.config import opal_client_config
 from opal_client.logger import logger
@@ -125,8 +124,6 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
 
     # Initialize FastAPI Cache
     if sidecar_config.PDP_CACHE_ENABLED:
-        FastAPICache.init(InMemoryBackend(), prefix="pdp")
-        logger.info(f"Initialized FastAPI Cache with TTL: {sidecar_config.PDP_CACHE_TTL_SEC} seconds")
         conditional_cache = functools.partial(
             cache,
             expire=sidecar_config.PDP_CACHE_TTL_SEC,

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -123,10 +123,10 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
         return decorator
 
     # Initialize FastAPI Cache
-    if sidecar_config.PDP_CACHE_ENABLED:
+    if sidecar_config.CACHE_ENABLED:
         conditional_cache = functools.partial(
             cache,
-            expire=sidecar_config.PDP_CACHE_TTL_SEC,
+            expire=sidecar_config.CACHE_TTL_SEC,
         )
 
     if sidecar_config.KONG_INTEGRATION:

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -329,9 +329,9 @@ class PermitPDP:
         return app
 
     def _init_cache_if_enabled(self):
-        if sidecar_config.PDP_CACHE_ENABLED:
+        if sidecar_config.CACHE_ENABLED:
             FastAPICache.init(InMemoryBackend(), prefix="pdp")
-            logger.info(f"Initialized Cache with TTL: {sidecar_config.PDP_CACHE_TTL_SEC} seconds")
+            logger.info(f"Initialized Cache with TTL: {sidecar_config.CACHE_TTL_SEC} seconds")
 
     def _configure_api_routes(self, app: FastAPI):
         """

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -328,7 +328,7 @@ class PermitPDP:
         app.openapi_tags = sidecar_config.OPENAPI_TAGS_METADATA
         return app
 
-    async def _init_cache_if_enabled(self):
+    def _init_cache_if_enabled(self):
         if sidecar_config.PDP_CACHE_ENABLED:
             FastAPICache.init(InMemoryBackend(), prefix="pdp")
             logger.info(f"Initialized Cache with TTL: {sidecar_config.PDP_CACHE_TTL_SEC} seconds")

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -359,7 +359,6 @@ async def test_user_permissions_cache_no_store(mocked_api: aioresponses, client_
 
 @pytest.mark.asyncio
 async def test_user_permissions_cache_no_cache(mocked_api: aioresponses, client_with_cache: TestClient):
-    await FastAPICache.clear()
     """Test that Cache-Control: no-cache header forces revalidation"""
     client = client_with_cache
 

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -10,29 +10,29 @@ from test_enforcer_api import MockPermitPDP
 
 @pytest.fixture
 def sidecar_with_cache():
-    orig_config = sidecar_config.PDP_CACHE_ENABLED
-    orig_ttl = sidecar_config.PDP_CACHE_TTL_SEC
+    orig_config = sidecar_config.CACHE_ENABLED
+    orig_ttl = sidecar_config.CACHE_TTL_SEC
     # Enable caching for this test
-    sidecar_config.PDP_CACHE_ENABLED = True
-    sidecar_config.PDP_CACHE_TTL_SEC = 3600
+    sidecar_config.CACHE_ENABLED = True
+    sidecar_config.CACHE_TTL_SEC = 3600
     _mock_pdp = MockPermitPDP()
     _mock_pdp._init_cache_if_enabled()
     yield _mock_pdp
     # Restore the original config
-    sidecar_config.PDP_CACHE_ENABLED = orig_config
-    sidecar_config.PDP_CACHE_TTL_SEC = orig_ttl
+    sidecar_config.CACHE_ENABLED = orig_config
+    sidecar_config.CACHE_TTL_SEC = orig_ttl
 
 
 @pytest.fixture
 def sidecar_without_cache():
-    orig_config = sidecar_config.PDP_CACHE_ENABLED
+    orig_config = sidecar_config.CACHE_ENABLED
     # Disable caching for this test
-    sidecar_config.PDP_CACHE_ENABLED = False
+    sidecar_config.CACHE_ENABLED = False
     _mock_pdp = MockPermitPDP()
     _mock_pdp._init_cache_if_enabled()
     yield _mock_pdp
     # Restore the original config
-    sidecar_config.PDP_CACHE_ENABLED = orig_config
+    sidecar_config.CACHE_ENABLED = orig_config
 
 
 @pytest.fixture

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -26,7 +26,9 @@ def sidecar_without_cache():
     orig_config = sidecar_config.PDP_CACHE_ENABLED
     # Disable caching for this test
     sidecar_config.PDP_CACHE_ENABLED = False
-    yield MockPermitPDP()
+    _mock_pdp = MockPermitPDP()
+    _mock_pdp._init_cache_if_enabled()
+    yield _mock_pdp
     # Restore the original config
     sidecar_config.PDP_CACHE_ENABLED = orig_config
 
@@ -39,14 +41,12 @@ def mocked_api():
 
 @pytest.fixture
 def client_with_cache(sidecar_with_cache: MockPermitPDP):
-    with TestClient(sidecar_with_cache.app) as c:
-        yield c
+    return TestClient(sidecar_with_cache.app)
 
 
 @pytest.fixture
 def client_without_cache(sidecar_without_cache: MockPermitPDP):
-    with TestClient(sidecar_without_cache.app) as c:
-        yield c
+    return TestClient(sidecar_without_cache.app)
 
 
 @pytest.mark.asyncio

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -1,6 +1,7 @@
 import pytest
 from aioresponses import aioresponses
 from fastapi.testclient import TestClient
+from fastapi_cache import FastAPICache
 from horizon.config import sidecar_config
 from horizon.enforcer.schemas import User, UserPermissionsQuery
 from opal_client.config import opal_client_config
@@ -9,22 +10,31 @@ from test_enforcer_api import MockPermitPDP
 
 @pytest.fixture
 def sidecar_with_cache():
+    orig_config = sidecar_config.PDP_CACHE_ENABLED
+    orig_ttl = sidecar_config.PDP_CACHE_TTL_SEC
     # Enable caching for this test
     sidecar_config.PDP_CACHE_ENABLED = True
     sidecar_config.PDP_CACHE_TTL_SEC = 3600
-    return MockPermitPDP()
+    yield MockPermitPDP()
+    # Restore the original config
+    sidecar_config.PDP_CACHE_ENABLED = orig_config
+    sidecar_config.PDP_CACHE_TTL_SEC = orig_ttl
 
 
 @pytest.fixture
 def sidecar_without_cache():
+    orig_config = sidecar_config.PDP_CACHE_ENABLED
     # Disable caching for this test
     sidecar_config.PDP_CACHE_ENABLED = False
-    return MockPermitPDP()
+    yield MockPermitPDP()
+    # Restore the original config
+    sidecar_config.PDP_CACHE_ENABLED = orig_config
 
 
 @pytest.fixture
 def mocked_api():
-    return aioresponses()
+    with aioresponses() as mocked_api:
+        yield mocked_api
 
 
 @pytest.fixture
@@ -41,6 +51,7 @@ def client_without_cache(sidecar_without_cache: MockPermitPDP):
 
 @pytest.mark.asyncio
 async def test_user_permissions_cache(mocked_api: aioresponses, client_with_cache: TestClient):
+    await FastAPICache.clear()
     """Test that user permissions are cached when caching is enabled"""
     client = client_with_cache
 
@@ -72,33 +83,32 @@ async def test_user_permissions_cache(mocked_api: aioresponses, client_with_cach
         }
     }
 
-    with mocked_api:
-        # Mock the OPA response
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response,
-            # we mock only once because on the second request the cache will be hit
-            # and we want to make sure it's working
-            repeat=False,
-        )
+    # Mock the OPA response
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response,
+        # we mock only once because on the second request the cache will be hit
+        # and we want to make sure it's working
+        repeat=False,
+    )
 
-        # First request should hit the API
-        response = client.post(
-            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # First request should hit the API
+    response = client.post(
+        "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Second request should be served from cache
-        response = client.post(
-            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # Second request should be served from cache
+    response = client.post(
+        "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 1
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 1
 
 
 @pytest.mark.asyncio
@@ -135,35 +145,35 @@ async def test_user_permissions_no_cache(mocked_api: aioresponses, client_withou
         }
     }
 
-    with mocked_api:
-        # Mock the OPA response
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response,
-            repeat=True,
-        )
+    # Mock the OPA response
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response,
+        repeat=True,
+    )
 
-        # First request should hit the API
-        response = client.post(
-            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # First request should hit the API
+    response = client.post(
+        "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Second request should also hit the API (no caching)
-        response = client.post(
-            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # Second request should also hit the API (no caching)
+    response = client.post(
+        "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 2
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 2
 
 
 @pytest.mark.asyncio
 async def test_user_permissions_cache_different_users(mocked_api: aioresponses, client_with_cache: TestClient):
+    await FastAPICache.clear()
     """Test that different users get different cache entries"""
     client = client_with_cache
 
@@ -223,70 +233,69 @@ async def test_user_permissions_cache_different_users(mocked_api: aioresponses, 
         }
     }
 
-    with mocked_api:
-        # Mock the OPA responses for both users
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response1,
-            # we mock only once because on the second request the cache will be hit
-            # and we want to make sure it's working
-            repeat=False,
-        )
+    # Mock the OPA responses for both users
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response1,
+        # we mock only once because on the second request the cache will be hit
+        # and we want to make sure it's working
+        repeat=False,
+    )
 
-        # First request for user1 should hit the API
-        response = client.post(
-            "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response1
+    # First request for user1 should hit the API
+    response = client.post(
+        "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response1
 
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 1
-        # Second request for user1 should be served from cache
-        response = client.post(
-            "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response1
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 1
+    # Second request for user1 should be served from cache
+    response = client.post(
+        "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response1
 
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 1
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 1
 
-        # Clear the mock and set up response for user2
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response2,
-            # we mock only once because on the second request the cache will be hit
-            # and we want to make sure it's working
-            repeat=False,
-        )
+    # Clear the mock and set up response for user2
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response2,
+        # we mock only once because on the second request the cache will be hit
+        # and we want to make sure it's working
+        repeat=False,
+    )
 
-        # First request for user2 should hit the API
-        response = client.post(
-            "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response2
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 2
+    # First request for user2 should hit the API
+    response = client.post(
+        "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response2
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 2
 
-        # Second request for user2 should be served from cache
-        response = client.post(
-            "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response2
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 2
+    # Second request for user2 should be served from cache
+    response = client.post(
+        "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response2
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 2
 
 
 @pytest.mark.asyncio
 async def test_user_permissions_cache_no_store(mocked_api: aioresponses, client_with_cache: TestClient):
     """Test that Cache-Control: no-store header prevents caching"""
+    await FastAPICache.clear()
     client = client_with_cache
-
     query = UserPermissionsQuery(user=User(key="test_user"), resource_types=["resource1"])
 
     opa_response = {
@@ -315,42 +324,42 @@ async def test_user_permissions_cache_no_store(mocked_api: aioresponses, client_
         }
     }
 
-    with mocked_api:
-        # Mock the OPA response
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response,
-            repeat=True,  # Need to repeat since cache should be bypassed
-        )
+    # Mock the OPA response
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response,
+        repeat=True,  # Need to repeat since cache should be bypassed
+    )
 
-        # First request with no-store header
-        response = client.post(
-            "/user-permissions",
-            json=query.dict(),
-            headers={"Authorization": f"Bearer {sidecar_config.API_KEY}", "Cache-Control": "no-store"},
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # First request with no-store header
+    response = client.post(
+        "/user-permissions",
+        json=query.dict(),
+        headers={"Authorization": f"Bearer {sidecar_config.API_KEY}", "Cache-Control": "no-store"},
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Second request with no-store header should also hit the API
-        response = client.post(
-            "/user-permissions",
-            json=query.dict(),
-            headers={
-                "Authorization": f"Bearer {sidecar_config.API_KEY}",
-            },
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # Second request with no-store header should also hit the API
+    response = client.post(
+        "/user-permissions",
+        json=query.dict(),
+        headers={
+            "Authorization": f"Bearer {sidecar_config.API_KEY}",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Verify that both requests hit the API
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 2
+    # Verify that both requests hit the API
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 2
 
 
 @pytest.mark.asyncio
 async def test_user_permissions_cache_no_cache(mocked_api: aioresponses, client_with_cache: TestClient):
+    await FastAPICache.clear()
     """Test that Cache-Control: no-cache header forces revalidation"""
     client = client_with_cache
 
@@ -382,54 +391,53 @@ async def test_user_permissions_cache_no_cache(mocked_api: aioresponses, client_
         }
     }
 
-    with mocked_api:
-        # Mock the OPA response
-        mocked_api.post(
-            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
-            status=200,
-            payload=opa_response,
-            repeat=True,  # Need to repeat since cache should be revalidated
-        )
+    # Mock the OPA response
+    mocked_api.post(
+        f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+        status=200,
+        payload=opa_response,
+        repeat=True,  # Need to repeat since cache should be revalidated
+    )
 
-        # First request with no-cache header
-        response = client.post(
-            "/user-permissions",
-            json=query.dict(),
-            headers={
-                "Authorization": f"Bearer {sidecar_config.API_KEY}",
-            },
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # First request with no-cache header
+    response = client.post(
+        "/user-permissions",
+        json=query.dict(),
+        headers={
+            "Authorization": f"Bearer {sidecar_config.API_KEY}",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Verify that both requests hit the API
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 1
+    # Verify that both requests hit the API
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 1
 
-        # First request with no-cache header
-        response = client.post(
-            "/user-permissions",
-            json=query.dict(),
-            headers={
-                "Authorization": f"Bearer {sidecar_config.API_KEY}",
-            },
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # First request with no-cache header
+    response = client.post(
+        "/user-permissions",
+        json=query.dict(),
+        headers={
+            "Authorization": f"Bearer {sidecar_config.API_KEY}",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Verify that both requests hit the API
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 1
+    # Verify that both requests hit the API
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 1
 
-        # Second request with no-cache header should revalidate
-        response = client.post(
-            "/user-permissions",
-            json=query.dict(),
-            headers={"Authorization": f"Bearer {sidecar_config.API_KEY}", "Cache-Control": "no-cache"},
-        )
-        assert response.status_code == 200
-        assert response.json() == expected_response
+    # Second request with no-cache header should revalidate
+    response = client.post(
+        "/user-permissions",
+        json=query.dict(),
+        headers={"Authorization": f"Bearer {sidecar_config.API_KEY}", "Cache-Control": "no-cache"},
+    )
+    assert response.status_code == 200
+    assert response.json() == expected_response
 
-        # Verify that both requests hit the API
-        assert len(mocked_api.requests) == 1
-        assert len(next(iter(mocked_api.requests.values()))) == 2
+    # Verify that both requests hit the API
+    assert len(mocked_api.requests) == 1
+    assert len(next(iter(mocked_api.requests.values()))) == 2

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -15,7 +15,9 @@ def sidecar_with_cache():
     # Enable caching for this test
     sidecar_config.PDP_CACHE_ENABLED = True
     sidecar_config.PDP_CACHE_TTL_SEC = 3600
-    yield MockPermitPDP()
+    _mock_pdp = MockPermitPDP()
+    _mock_pdp._init_cache_if_enabled()
+    yield _mock_pdp
     # Restore the original config
     sidecar_config.PDP_CACHE_ENABLED = orig_config
     sidecar_config.PDP_CACHE_TTL_SEC = orig_ttl
@@ -360,6 +362,7 @@ async def test_user_permissions_cache_no_store(mocked_api: aioresponses, client_
 @pytest.mark.asyncio
 async def test_user_permissions_cache_no_cache(mocked_api: aioresponses, client_with_cache: TestClient):
     """Test that Cache-Control: no-cache header forces revalidation"""
+    await FastAPICache.clear()
     client = client_with_cache
 
     query = UserPermissionsQuery(user=User(key="test_user"), resource_types=["resource1"])

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -3,8 +3,8 @@ from aioresponses import aioresponses
 from fastapi.testclient import TestClient
 from horizon.config import sidecar_config
 from horizon.enforcer.schemas import User, UserPermissionsQuery
-from horizon.tests.test_enforcer_api import MockPermitPDP
 from opal_client.config import opal_client_config
+from test_enforcer_api import MockPermitPDP
 
 
 @pytest.fixture

--- a/horizon/tests/test_enforcer_cache.py
+++ b/horizon/tests/test_enforcer_cache.py
@@ -1,0 +1,282 @@
+import pytest
+from aioresponses import aioresponses
+from fastapi.testclient import TestClient
+from horizon.config import sidecar_config
+from horizon.enforcer.schemas import User, UserPermissionsQuery
+from horizon.tests.test_enforcer_api import MockPermitPDP
+from opal_client.config import opal_client_config
+
+
+@pytest.fixture
+def sidecar_with_cache():
+    # Enable caching for this test
+    sidecar_config.PDP_CACHE_ENABLED = True
+    sidecar_config.PDP_CACHE_TTL_SEC = 3600
+    return MockPermitPDP()
+
+
+@pytest.fixture
+def sidecar_without_cache():
+    # Disable caching for this test
+    sidecar_config.PDP_CACHE_ENABLED = False
+    return MockPermitPDP()
+
+
+@pytest.fixture
+def mocked_api():
+    return aioresponses()
+
+
+@pytest.fixture
+def client_with_cache(sidecar_with_cache: MockPermitPDP):
+    with TestClient(sidecar_with_cache.app) as c:
+        yield c
+
+
+@pytest.fixture
+def client_without_cache(sidecar_without_cache: MockPermitPDP):
+    with TestClient(sidecar_without_cache.app) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_user_permissions_cache(mocked_api: aioresponses, client_with_cache: TestClient):
+    """Test that user permissions are cached when caching is enabled"""
+    client = client_with_cache
+
+    query = UserPermissionsQuery(user=User(key="test_user"), resource_types=["resource1"])
+
+    opa_response = {
+        "result": {
+            "permissions": {
+                "test_user": {
+                    "resource": {
+                        "key": "resource_x",
+                        "attributes": {},
+                        "type": "resource1",
+                    },
+                    "permissions": ["read:read"],
+                }
+            }
+        }
+    }
+
+    expected_response = {
+        "test_user": {
+            "resource": {
+                "key": "resource_x",
+                "attributes": {},
+                "type": "resource1",
+            },
+            "permissions": ["read:read"],
+        }
+    }
+
+    with mocked_api:
+        # Mock the OPA response
+        mocked_api.post(
+            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+            status=200,
+            payload=opa_response,
+            # we mock only once because on the second request the cache will be hit
+            # and we want to make sure it's working
+            repeat=False,
+        )
+
+        # First request should hit the API
+        response = client.post(
+            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+        # Second request should be served from cache
+        response = client.post(
+            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 1
+
+
+@pytest.mark.asyncio
+async def test_user_permissions_no_cache(mocked_api: aioresponses, client_without_cache: TestClient):
+    """Test that user permissions are not cached when caching is disabled"""
+    # Disable caching for this test
+    client = client_without_cache
+
+    query = UserPermissionsQuery(user=User(key="test_user"), resource_types=["resource1"])
+
+    opa_response = {
+        "result": {
+            "permissions": {
+                "test_user": {
+                    "resource": {
+                        "key": "resource_x",
+                        "attributes": {},
+                        "type": "resource1",
+                    },
+                    "permissions": ["read:read"],
+                }
+            }
+        }
+    }
+
+    expected_response = {
+        "test_user": {
+            "resource": {
+                "key": "resource_x",
+                "attributes": {},
+                "type": "resource1",
+            },
+            "permissions": ["read:read"],
+        }
+    }
+
+    with mocked_api:
+        # Mock the OPA response
+        mocked_api.post(
+            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+            status=200,
+            payload=opa_response,
+            repeat=True,
+        )
+
+        # First request should hit the API
+        response = client.post(
+            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+        # Second request should also hit the API (no caching)
+        response = client.post(
+            "/user-permissions", json=query.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 2
+
+
+@pytest.mark.asyncio
+async def test_user_permissions_cache_different_users(mocked_api: aioresponses, client_with_cache: TestClient):
+    """Test that different users get different cache entries"""
+    client = client_with_cache
+
+    query1 = UserPermissionsQuery(user=User(key="user1"), resource_types=["resource1"])
+
+    query2 = UserPermissionsQuery(user=User(key="user2"), resource_types=["resource1"])
+
+    opa_response1 = {
+        "result": {
+            "permissions": {
+                "user1": {
+                    "resource": {
+                        "key": "resource_x",
+                        "attributes": {},
+                        "type": "resource1",
+                    },
+                    "permissions": ["read:read"],
+                }
+            }
+        }
+    }
+
+    opa_response2 = {
+        "result": {
+            "permissions": {
+                "user2": {
+                    "resource": {
+                        "key": "resource_x",
+                        "attributes": {},
+                        "type": "resource1",
+                    },
+                    "permissions": ["write:write"],
+                }
+            }
+        }
+    }
+
+    expected_response1 = {
+        "user1": {
+            "resource": {
+                "key": "resource_x",
+                "attributes": {},
+                "type": "resource1",
+            },
+            "permissions": ["read:read"],
+        }
+    }
+
+    expected_response2 = {
+        "user2": {
+            "resource": {
+                "key": "resource_x",
+                "attributes": {},
+                "type": "resource1",
+            },
+            "permissions": ["write:write"],
+        }
+    }
+
+    with mocked_api:
+        # Mock the OPA responses for both users
+        mocked_api.post(
+            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+            status=200,
+            payload=opa_response1,
+            # we mock only once because on the second request the cache will be hit
+            # and we want to make sure it's working
+            repeat=False,
+        )
+
+        # First request for user1 should hit the API
+        response = client.post(
+            "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response1
+
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 1
+        # Second request for user1 should be served from cache
+        response = client.post(
+            "/user-permissions", json=query1.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response1
+
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 1
+
+        # Clear the mock and set up response for user2
+        mocked_api.post(
+            f"{opal_client_config.POLICY_STORE_URL}/v1/data/permit/user_permissions",
+            status=200,
+            payload=opa_response2,
+            # we mock only once because on the second request the cache will be hit
+            # and we want to make sure it's working
+            repeat=False,
+        )
+
+        # First request for user2 should hit the API
+        response = client.post(
+            "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response2
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 2
+
+        # Second request for user2 should be served from cache
+        response = client.post(
+            "/user-permissions", json=query2.dict(), headers={"Authorization": f"Bearer {sidecar_config.API_KEY}"}
+        )
+        assert response.status_code == 200
+        assert response.json() == expected_response2
+        assert len(mocked_api.requests) == 1
+        assert len(next(iter(mocked_api.requests.values()))) == 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ httpx>=0.27.0,<1
 protobuf>=3.20.2 # not directly required, pinned by Snyk to avoid a vulnerability
 opal-common==0.8.0
 opal-client==0.8.0
+fastapi-cache2==0.2.2
+orjson==3.10.16


### PR DESCRIPTION
- Introduced configuration options for enabling caching and setting TTL for PDP responses in `horizon/config.py`.
- Enhanced the enforcer API to utilize FastAPI caching, including a custom key builder for user permissions.
- Implemented tests to verify caching behavior for user permissions, ensuring correct responses are served from cache when enabled and that different users receive distinct cache entries.
- Updated existing functions to support caching logic and improved logging for query results.