### PR TITLE
Add niceness configuration for process priority control

### DIFF
--- a/horizon/config.py
+++ b/horizon/config.py
@@ -265,6 +265,16 @@ class SidecarConfig(Confi):
         description="The path to the file that contains the PDP version",
     )
 
+    HORIZON_NICENESS = confi.int(
+        "HORIZON_NICENESS",
+        10,
+        description=(
+            "The niceness value for the PDP Horizon process (Python process). "
+            "Niceness values range from -20 (highest priority) to 19 (lowest priority) with 0 is neutral. "
+            "Adjusting this can help manage CPU resource allocation. "
+        ),
+    )
+
     @staticmethod
     def parse_callbacks(value: Any) -> list[CallbackEntry]:
         if isinstance(value, str):


### PR DESCRIPTION
Introduce the `HORIZON_NICENESS` configuration to control the process niceness value, enabling better CPU resource allocation. Implemented `set_process_niceness` to adjust the process priority based on the specified value, with safety checks and logging for status and errors. This ensures processes can be fine-tuned for performance or background execution as needed.