### PR TITLE
feat: add option to use standard helm naming conventions

### DIFF
--- a/charts/pdp/templates/_helpers.tpl
+++ b/charts/pdp/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "..name" -}}
+{{- define "pdp.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "..fullname" -}}
+{{- define "pdp.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -48,7 +48,7 @@ Get the secret name for the API key
 {{- .Values.pdp.existingApiKeySecret.name -}}
 {{- else -}}
 {{- if .Values.useStandardHelmNamingConventions }}
-{{- include "..fullname" . }}
+{{- include "pdp.fullname" . }}
 {{- else -}}
 permitio-pdp-secret
 {{- end -}}

--- a/charts/pdp/templates/deployment.yaml
+++ b/charts/pdp/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   {{- if .Values.useStandardHelmNamingConventions }}
-  name: {{ include "..fullname" . }}
+  name: {{ include "pdp.fullname" . }}
   {{- else }}
   name: permitio-pdp
   {{- end }}
@@ -149,7 +149,7 @@ spec:
       {{- if .Values.pdp.logs_forwarder.enabled }}
         - name: fluent-bit-config
           configMap:
-            name: fluentbit-config
+            name: {{ include "pdp.fullname" . }}-fluentbit-config
         - name: logs
           emptyDir: {}
       {{- else if .Values.openshift.enabled }}

--- a/charts/pdp/templates/logs-forwarder-cm.yaml
+++ b/charts/pdp/templates/logs-forwarder-cm.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   {{- if .Values.useStandardHelmNamingConventions }}
-  name: {{ include "..fullname" . }}-fluentbit-config
+  name: {{ include "pdp.fullname" . }}-fluentbit-config
   {{- else }}
   name: fluentbit-config
   {{- end }}

--- a/charts/pdp/templates/poddisruptionbudget.yaml
+++ b/charts/pdp/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   {{- if .Values.useStandardHelmNamingConventions }}
-  name: {{ include "..fullname" . }}
+  name: {{ include "pdp.fullname" . }}
   {{- else }}
   name: permitio-pdp-pdb
   {{- end }}

--- a/charts/pdp/templates/service.yaml
+++ b/charts/pdp/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   {{- if .Values.useStandardHelmNamingConventions }}
-  name: {{ include "..fullname" . }}
+  name: {{ include "pdp.fullname" . }}
   {{- else }}
   name: permitio-pdp
   {{- end }}

--- a/charts/pdp/values.yaml
+++ b/charts/pdp/values.yaml
@@ -19,6 +19,7 @@ labels: {}
 annotations: {}
 
 nameOverride: ""
+fullnameOverride: ""
 
 pdp:
   pdpEnvs:
@@ -77,11 +78,11 @@ resources:
 
 # OpenShift configuration
 openshift:
-  enabled: false  # Set to true for OpenShift deployments
+  enabled: false # Set to true for OpenShift deployments
   serviceAccount:
     create: true
     name: "permitio-pdp-sa"
-    sccName: "restricted-v2"  # OpenShift Security Context Constraint
+    sccName: "restricted-v2" # OpenShift Security Context Constraint
   # Security context (SCC will override user/group settings automatically)
   securityContext:
     runAsNonRoot: true


### PR DESCRIPTION
This pull request introduces support for standard Helm naming conventions in the `charts/pdp` Helm chart while preserving backward compatibility with the existing naming scheme. It adds a feature flag (`useStandardHelmNamingConventions`) to toggle between the naming conventions. 

This is the standard naming convention of resources virtually all helm charts use. Defining static names as is currently done presents the risk of potential name collisions with other resources and/or other PDP deployments in the same namespace. 