### PR TITLE
Refactor OpenAPI routes and add new handlers for documentation endpoints

### DIFF
--- a/pdp-server/src/main.rs
+++ b/pdp-server/src/main.rs
@@ -39,7 +39,6 @@ async fn main() {
             std::process::exit(1);
         }
     };
-
     // Initialize application state
     let state: AppState = AppState::with_existing_cache(&config, cache)
         .await
@@ -85,7 +84,7 @@ pub async fn create_app(state: AppState) -> Router {
     Router::new()
         .merge(api::router(&state))
         .merge(openapi_router)
-        .merge(Scalar::with_url("/scalar", api_doc.clone()))
+        .merge(crate::openapi::router())
         .with_state(state)
 }
 

--- a/pdp-server/src/main.rs
+++ b/pdp-server/src/main.rs
@@ -15,7 +15,6 @@ use log::{error, info};
 use std::net::SocketAddr;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
-use utoipa_scalar::{Scalar, Servable};
 
 #[tokio::main]
 async fn main() {
@@ -77,8 +76,7 @@ async fn main() {
 /// Create a new application instance with a given state
 pub async fn create_app(state: AppState) -> Router {
     // Create OpenAPI documentation
-    let (openapi_router, api_doc) =
-        OpenApiRouter::with_openapi(openapi::ApiDoc::openapi()).split_for_parts();
+    let openapi_router = OpenApiRouter::with_openapi(openapi::ApiDoc::openapi());
 
     // Create base router with routes
     Router::new()

--- a/pdp-server/src/openapi.rs
+++ b/pdp-server/src/openapi.rs
@@ -1,3 +1,9 @@
+use crate::state::AppState;
+use axum::body::Body;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{extract::State, routing::get, Router};
+use http::HeaderValue;
 use utoipa::OpenApi;
 
 pub(crate) const HEALTH_TAG: &str = "Health API";
@@ -17,3 +23,95 @@ pub(crate) const AUTHZEN_TAG: &str = "AuthZen API";
     )
 )]
 pub(crate) struct ApiDoc;
+
+/// Handler for the OpenAPI JSON specification endpoint
+async fn openapi_json_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let openapi_url = state.config.horizon.get_url("/openapi.json");
+
+    match state.horizon_client.get(&openapi_url).send().await {
+        Ok(response) => match response.bytes().await {
+            Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Ok(json) => axum::Json(json).into_response(),
+                Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Invalid JSON").into_response(),
+            },
+            Err(_) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read response").into_response()
+            }
+        },
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Horizon service unavailable",
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for the ReDoc documentation endpoint
+async fn redoc_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let redoc_url = state.config.horizon.get_url("/redoc");
+
+    match state.horizon_client.get(&redoc_url).send().await {
+        Ok(response) => {
+            // Extract content-type header before consuming the response
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .unwrap_or(&HeaderValue::from_static("text/html"))
+                .clone();
+
+            match response.text().await {
+                Ok(text) => Response::builder()
+                    .header("content-type", content_type)
+                    .body(Body::from(text))
+                    .unwrap(),
+                Err(_) => {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read response").into_response()
+                }
+            }
+        }
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Horizon service unavailable",
+        )
+            .into_response(),
+    }
+}
+
+/// Handler for the Scalar documentation endpoint
+async fn scalar_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let scalar_url = state.config.horizon.get_url("/scalar");
+
+    match state.horizon_client.get(&scalar_url).send().await {
+        Ok(response) => {
+            // Extract content-type header before consuming the response
+            let content_type = response
+                .headers()
+                .get("content-type")
+                .unwrap_or(&HeaderValue::from_static("text/html"))
+                .clone();
+
+            match response.text().await {
+                Ok(res_text) => Response::builder()
+                    .header("content-type", content_type)
+                    .body(Body::from(res_text))
+                    .unwrap(),
+                Err(_) => {
+                    (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read response").into_response()
+                }
+            }
+        }
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Horizon service unavailable",
+        )
+            .into_response(),
+    }
+}
+
+/// Creates a router for OpenAPI documentation routes
+pub(crate) fn router() -> Router<AppState> {
+    Router::new()
+        .route("/openapi.json", get(openapi_json_handler))
+        .route("/redoc", get(redoc_handler))
+        .route("/scalar", get(scalar_handler))
+}


### PR DESCRIPTION
- Updated the main application to integrate the OpenAPI router.
- Added handlers for OpenAPI JSON, ReDoc, and Scalar documentation endpoints in `openapi.rs`.
- Improved error handling for HTTP responses in the new handlers.
- Cleaned up code formatting in `main.rs` for better readability.


@danyi1212 I had few attempts to fix our broken openapi generation in the rust and trying to merge it with the horizon openapi
for some reason both serialization of the oppenapi json in the horizon failed and it was cranky anyway