### PR TITLE
Deprecate PDP-Vanilla build steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,28 +14,6 @@ jobs:
     uses: ./.github/workflows/tests.yml
     secrets: inherit
 
-  build-and-push-pdp-vanilla:
-    needs: pdp-tests
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Pre build - for PDP-Vanilla
-      run: echo "${{ github.event.release.tag_name }}" | cut -d '-' -f 1 > permit_pdp_version
-
   build-and-push-pdp:
     needs: pdp-tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes PDP-Vanilla image build/publish steps from the release workflow, keeping only the main PDP image build and downstream steps.
> 
> - **CI Release Workflow (`.github/workflows/release.yml`)**:
>   - **Deprecate PDP-Vanilla build**:
>     - Remove `docker/build-push-action` steps that built and pushed `permitio/pdp-v2-vanilla` for both prereleases and official releases.
>     - Retain the pre-build step generating `permit_pdp_version` for PDP-Vanilla job.
>   - **Unchanged**: Main PDP build/publish logic (`permitio/pdp-v2`) and ECS service redeploy remain intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8d433224c89d38844d5ea1c55b2db55cbd7719c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->