### PR TITLE
fix: patch CVE-2025-70873 by bumping base image to python:3.10-alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # MAIN IMAGE ----------------------------------------
 # Main image setup (optimized)
 # ---------------------------------------------------
-FROM python:3.10-alpine3.22 AS main
+# Alpine 3.23+ ships sqlite-libs >= 3.51.2 which fixes CVE-2025-70873
+# (info disclosure in SQLite zipfile extension's zipfileInflate).
+FROM python:3.10-alpine3.23 AS main
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Bumps the runtime base image from `python:3.10-alpine3.22` → `python:3.10-alpine3.23` to remediate **CVE-2025-70873** (information disclosure in SQLite's `zipfile` extension `zipfileInflate`, fixed upstream in SQLite 3.51.2).
- Alpine 3.22 main ships `sqlite-libs 3.49.2-r1` (vulnerable). Alpine 3.23 ships `sqlite-libs 3.51.2-r0`, which contains the fix.
- `apk del sqlite` already in the Dockerfile only drops the CLI; `sqlite-libs` remains because Python's stdlib `_sqlite3` module is dynamically linked against it — so a base-image bump is required to actually clear the finding.
- Build-only stages (`rust:1.94-alpine`, `golang:1.25-bookworm`) don't contribute layers to the runtime image, so no changes needed there.

## Test plan

- [ ] CI builds the image successfully on both `linux/amd64` and `linux/arm64`.
- [ ] E2E tests pass against the rebuilt image.
- [ ] Docker Scout no longer reports CVE-2025-70873 (sqlite-libs ≥ 3.51.2-r0).
- [ ] No regression in `apk add bash libffi libressl gcompat` or the pip build-deps virtual package on Alpine 3.23.

## References

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-70873
- Alpine 3.23 sqlite-libs: https://pkgs.alpinelinux.org/package/v3.23/main/x86_64/sqlite-libs