### PR TITLE
chore: upgrade OPAL to 0.9.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ httpx>=0.27.0,<1
 # google-re2 # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
 protobuf>=6.33.5 # pinned to avoid CVE-2026-0994
 cryptography>=46.0.5,<47 # pinned to avoid CVE-2026-26007
-opal-common==0.9.4
-opal-client==0.9.4
+opal-common==0.9.5rc2
+opal-client==0.9.5rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ httpx>=0.27.0,<1
 # google-re2 # use re2 instead of re for regex matching because it's simiplier and safer for user inputted regexes
 protobuf>=6.33.5 # pinned to avoid CVE-2026-0994
 cryptography>=46.0.5,<47 # pinned to avoid CVE-2026-26007
-opal-common==0.9.5rc2
-opal-client==0.9.5rc2
+opal-common==0.9.5
+opal-client==0.9.5


### PR DESCRIPTION
## Summary

Bump `opal-common` and `opal-client` from `0.9.4` to `0.9.5` (GA, published 2026-04-28) in `requirements.txt`.

## Notable upstream changes since 0.9.4

- `fix(opal-server)`: per-source key for `repos_last_fetched` dedup cache ([opal#903](https://github.com/permitio/opal/pull/903))
- `feat(client)`: live liveness probe for OPA policy store ([opal#904](https://github.com/permitio/opal/pull/904))
- `fix`: redoc url ([opal#905](https://github.com/permitio/opal/pull/905))
- Various opal-plus sync workflow fixes

Full changelog: https://github.com/permitio/opal/compare/0.9.4...0.9.5

## Test plan

- [ ] CI is green (lint, unit tests, docker build)
- [ ] Local docker build succeeds (`make build`)
- [ ] PDP starts and connects to OPAL server successfully
- [ ] Policy and data updates are received and applied as expected
- [ ] Smoke-check the new OPA liveness probe behavior

## Notes

- The branch was originally cut against `0.9.5-rc.2` (hence the branch name); after `0.9.5` was released as GA the pin was bumped to the stable version. The branch name is left as-is to avoid disrupting the existing PR.