### PR TITLE
Add nodeselector, affinity, and toleration configuration options to the helm chart

### DIFF
--- a/charts/pdp/templates/deployment.yaml
+++ b/charts/pdp/templates/deployment.yaml
@@ -155,3 +155,15 @@ spec:
         - name: opa-volume
           emptyDir: {}
       {{- end }}
+      {{- with .Values.pdp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pdp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pdp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/pdp/values.yaml
+++ b/charts/pdp/values.yaml
@@ -42,6 +42,9 @@ pdp:
       port: 443
       index: "<elasticsearch index>"
   debug_mode: false
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 podDisruptionBudget:
   # Automatically enabled when replicas > 1


### PR DESCRIPTION
This change allows users to optionally define nodeselector, affinity, and/or toleration options to their deployments via helm values. This allows users to better distribute their PDP deployments across their node pools. The default values for each are empty, ensuring this change does not affect existing deployments.

Closes #310 