### PR TITLE
Preserve repeated facts query params

### DIFF
--- a/horizon/facts/client.py
+++ b/horizon/facts/client.py
@@ -67,7 +67,11 @@ class FactsClient:
             )
 
         full_path = urljoin(f"/v2/facts/{project_id}/{environment_id}/", path.removeprefix("/"))
-        _query_params = {**request.query_params, **(query_params or {})}
+        _query_params = list(request.query_params.multi_items())
+        if query_params:
+            override_keys = set(query_params)
+            _query_params = [(key, value) for key, value in _query_params if key not in override_keys]
+            _query_params.extend(query_params.items())
         return self.client.build_request(
             method=request.method,
             url=full_path,

--- a/horizon/tests/test_facts_client.py
+++ b/horizon/tests/test_facts_client.py
@@ -5,13 +5,13 @@ from horizon.facts.client import CONSISTENT_UPDATE_HEADER, FactsClient
 from starlette.requests import Request as FastApiRequest
 
 
-def _make_request(headers: dict[str, str] | None = None) -> FastApiRequest:
+def _make_request(headers: dict[str, str] | None = None, query_string: bytes = b"") -> FastApiRequest:
     scope = {
         "type": "http",
         "method": "POST",
         "path": "/facts/users",
         "raw_path": b"/facts/users",
-        "query_string": b"",
+        "query_string": query_string,
         "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
     }
 
@@ -57,6 +57,46 @@ async def test_build_forward_request_omits_header_by_default():
         forward_request = await client.build_forward_request(request, "/anything")
 
         assert forward_request.headers.get(CONSISTENT_UPDATE_HEADER) is None
+
+
+@pytest.mark.asyncio
+async def test_build_forward_request_preserves_repeated_query_params():
+    client = FactsClient()
+
+    mock_remote_config = MagicMock()
+    mock_remote_config.context = {"project_id": "proj1", "env_id": "env1"}
+
+    with (
+        patch("horizon.facts.client.get_remote_config", return_value=mock_remote_config),
+        patch("horizon.facts.client.get_env_api_key", return_value="test_api_key"),
+    ):
+        request = _make_request(query_string=b"tenant=tenant_id&user=user_1&user=user_2")
+        forward_request = await client.build_forward_request(request, "/role_assignments")
+
+        assert forward_request.url.params.get_list("user") == ["user_1", "user_2"]
+        assert forward_request.url.params["tenant"] == "tenant_id"
+
+
+@pytest.mark.asyncio
+async def test_build_forward_request_query_param_overrides_replace_existing_values():
+    client = FactsClient()
+
+    mock_remote_config = MagicMock()
+    mock_remote_config.context = {"project_id": "proj1", "env_id": "env1"}
+
+    with (
+        patch("horizon.facts.client.get_remote_config", return_value=mock_remote_config),
+        patch("horizon.facts.client.get_env_api_key", return_value="test_api_key"),
+    ):
+        request = _make_request(query_string=b"return_deleted=false&user=user_1&user=user_2")
+        forward_request = await client.build_forward_request(
+            request,
+            "/role_assignments",
+            query_params={"return_deleted": True},
+        )
+
+        assert forward_request.url.params.get_list("user") == ["user_1", "user_2"]
+        assert forward_request.url.params["return_deleted"] == "true"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve repeated query parameters when forwarding facts requests to the control plane
- keep explicit forwarded query overrides replacing existing values
- add focused coverage for repeated params and override behavior

Fixes #299.

## Verification
- `.venv\Scripts\python -m pytest horizon\tests\test_facts_client.py`
- `.venv\Scripts\python -m pytest horizon\tests\test_facts_client.py horizon\tests\test_facts_router.py`
- `.venv\Scripts\python -m ruff check horizon\facts\client.py horizon\tests\test_facts_client.py`
- `git diff --check`

Implemented with Codex assistance, with the patch kept focused and manually reviewed before opening.