### PR TITLE
feat(helm): support user-provided API key env

### DIFF
--- a/charts/pdp/Chart.yaml
+++ b/charts/pdp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pdp
 description: An official Helm chart for Permit.io PDP (Policy Decision Point) with OpenShift support and configurable ports
-version: 0.0.6
+version: 0.0.7
 keywords:
   - policy
   - authorization

--- a/charts/pdp/templates/deployment.yaml
+++ b/charts/pdp/templates/deployment.yaml
@@ -50,11 +50,13 @@ spec:
               containerPort: {{ .targetPort }}
             {{- end }}
           env:
+            {{- if not .Values.pdp.userProvidedSecret }}
             - name: PDP_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "pdp.secretName" . }}
                   key: {{ include "pdp.secretKey" . }}
+            {{- end }}
             {{- if .Values.pdp.pdpEnvs }}
             {{- range .Values.pdp.pdpEnvs }}
             - name: {{ .name }}

--- a/charts/pdp/templates/secret.yaml
+++ b/charts/pdp/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.pdp.existingApiKeySecret }}
+{{- if and (not .Values.pdp.existingApiKeySecret) (not .Values.pdp.userProvidedSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pdp/values.yaml
+++ b/charts/pdp/values.yaml
@@ -17,6 +17,10 @@ pdp:
   # existingApiKeySecret:
   #   name: "my-existing-secret"
   #   key: "api-key"
+
+  # Set to true to skip creating and mounting an API key secret.
+  # Use this when PDP_API_KEY is injected through pdpEnvs or another external mechanism.
+  userProvidedSecret: false
   port: 7766
   # Example - expose Envoy gRPC ext_authz port (requires PDP_OPA_PLUGINS env var above):
   #   additionalPorts:


### PR DESCRIPTION
Summary:
- Add `pdp.userProvidedSecret` to let chart users skip creating the chart-managed API key Secret.
- Skip the default `PDP_API_KEY` `secretKeyRef` when that option is enabled, so users can inject `PDP_API_KEY` through `pdpEnvs` or another mechanism.
- Keep the existing `existingApiKeySecret` behavior unchanged and bump the chart patch version.

Verification:
- `helm lint charts/pdp`
- `helm template pdp charts/pdp`
- `helm template pdp charts/pdp -f <userProvidedSecret values>` rendered no Secret, no `secretKeyRef`, and included the user-provided `PDP_API_KEY` env.
- `helm template pdp charts/pdp -f <existingApiKeySecret values>` still rendered no Secret and kept the external `secretKeyRef`.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

Closes #300