### PR TITLE
ci: run pdp-tester via Docker runtime instead of k3d

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,9 +132,17 @@ jobs:
           AUTO_REMOVE: "false"
         run: |
           set -o pipefail
-          python -m pdp_tester --docker --local --tag next --skip-generate 2>&1 | tee /tmp/tester.log
+          # The default GitHub Actions shell runs with `-e`, so capture the
+          # tester's exit status explicitly (via `|| status=$?`) instead of
+          # letting a non-zero exit abort the step before the log is parsed.
+          status=0
+          python -m pdp_tester --docker --local --tag next --skip-generate 2>&1 | tee /tmp/tester.log || status=$?
           if grep -q "test cases failed" /tmp/tester.log; then
             echo "::error::Some test cases failed!"
+            exit 1
+          fi
+          if [ "$status" -ne 0 ]; then
+            echo "::error::pdp-tester exited with a non-zero status (${status})"
             exit 1
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,81 +104,53 @@ jobs:
           token: ${{ secrets.CLONE_REPO_TOKEN }}
           path: './pdp-tester'
 
-      # Start k3d cluster for Kubernetes-based pdp-tester
-      - name: Start k3d cluster
-        uses: AbsaOSS/k3d-action@v2.4.0
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          cluster-name: pdp-tester
-          args: --k3s-arg "--disable=traefik@server:0"
+          python-version: "3.12"
 
-      # Import PDP image into k3d with 'next' tag (locally built)
-      - name: Import PDP image into k3d
-        run: k3d image import permitio/pdp-v2:next -c pdp-tester
-
-      # Build pdp-tester image and import into k3d
-      - name: Build and import pdp-tester image
+      # Docker runtime backend: launch the PDP as a local container via aiodocker
+      # (no k3d/Helm/kubectl). This is the runtime the pdp-tester maintainers
+      # recommend for CI and sidesteps the AbsaOSS/k3d-action download breakage
+      # (its default k3d v5.4.6 has no checksums.txt, so install.sh now 404s).
+      - name: Install pdp-tester (docker extra)
         working-directory: ./pdp-tester
-        run: |
-          docker build -t pdp-tester:ci .
-          k3d image import pdp-tester:ci -c pdp-tester
+        run: pip install -e ".[docker]"
 
-      # Create namespace and secrets
-      - name: Create secrets
+      - name: Run PDP tester against the local Docker PDP image
+        working-directory: ./pdp-tester
         env:
-          PERMIT_TOKEN: ${{ secrets.PDP_TESTER_API_KEY }}
+          TOKEN: ${{ secrets.PDP_TESTER_API_KEY }}
+          API_URL: https://permitio.api.stg.permit.io
+          # Test the locally built image (loaded above) instead of pulling from
+          # Docker Hub. LOCAL_IMAGE forces the runtime's local-only tag path, so
+          # only permitio/pdp-v2:next is launched.
+          LOCAL_IMAGE: permitio/pdp-v2
+          # Preserve the previous Helm startTimeout, and keep crashed containers
+          # around so the post-mortem step below can read their logs.
+          START_TIMEOUT: "180"
+          AUTO_REMOVE: "false"
         run: |
-          kubectl create namespace pdp-tester || true
-          kubectl create secret generic pdp-tester-credentials \
-            -n pdp-tester \
-            --from-literal=token="${PERMIT_TOKEN}" \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      # Deploy pdp-tester via Helm with the "next" PDP image
-      - name: Deploy pdp-tester via Helm
-        working-directory: ./pdp-tester
-        run: |
-          helm install pdp-tester ./deploy/helm/pdp-tester \
-            --set mode=job \
-            --set permit.existingSecret=pdp-tester-credentials \
-            --set permit.apiUrl=https://permitio.api.stg.permit.io \
-            --set image.repository=pdp-tester \
-            --set image.tag=ci \
-            --set image.pullPolicy=Never \
-            --set pdp.image=permitio/pdp-v2 \
-            --set 'pdp.localTags[0]=next' \
-            --set 'pdp.includeTags=' \
-            --set tests.skipGenerate=true \
-            --set tests.startTimeout=180 \
-            --set namespace.create=false \
-            --set logJson=false
-
-      - name: Wait for Job completion
-        run: |
-          kubectl wait --for=condition=complete job/pdp-tester \
-            -n pdp-tester --timeout=600s
-
-      - name: Check test results
-        run: |
-          LOGS=$(kubectl logs job/pdp-tester -n pdp-tester)
-          echo "$LOGS" | tail -30
-          if echo "$LOGS" | grep -q "test cases failed"; then
+          set -o pipefail
+          python -m pdp_tester --docker --local --tag next --skip-generate 2>&1 | tee /tmp/tester.log
+          if grep -q "test cases failed" /tmp/tester.log; then
             echo "::error::Some test cases failed!"
             exit 1
           fi
 
-      - name: Print tester logs
+      - name: Capture PDP container state and logs
         if: always()
         run: |
-          echo "=== PDP Tester logs ==="
-          kubectl logs job/pdp-tester -n pdp-tester --tail=200 || true
+          echo "=== PDP containers (all states) ==="
+          docker ps -a --filter "label=pdp-tester.permit.io/managed-by=pdp-tester" \
+            --format '{{.Names}}\t{{.Status}}' || true
           echo ""
-          echo "=== PDP Pod logs ==="
-          kubectl logs -l pdp-tester.permit.io/managed-by=pdp-tester \
-            -n pdp-tester --tail=50 || true
-
-      - name: Teardown k3d cluster
-        if: always()
-        run: k3d cluster delete pdp-tester || true
+          echo "=== PDP container logs ==="
+          for c in $(docker ps -aq --filter "label=pdp-tester.permit.io/managed-by=pdp-tester"); do
+            name=$(docker inspect --format '{{.Name}}' "$c" | sed 's#^/##')
+            echo "--- ${name} ---"
+            docker logs "$c" 2>&1 | tail -200 || true
+          done
 
   docker-scout:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,11 @@ jobs:
   pdp-tester:
     runs-on: ubuntu-latest
     needs: build-pdp-image
+    # Cap the run so a hung tester fails fast instead of holding the runner
+    # until GitHub's 360-minute default. The old k3d path was bounded by
+    # `kubectl wait --timeout=600s`; the tester's own max_running_time only
+    # applies in interval mode, not the run-once mode CI uses.
+    timeout-minutes: 15
     steps:
       - name: Download Docker image artifact
         uses: actions/download-artifact@v4
@@ -108,6 +113,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          # Cache pdp-tester's deps so each run doesn't re-resolve/re-download
+          # from PyPI (faster, and resilient to transient PyPI outages).
+          cache: "pip"
+          cache-dependency-path: pdp-tester/pyproject.toml
 
       # Docker runtime backend: launch the PDP as a local container via aiodocker
       # (no k3d/Helm/kubectl). This is the runtime the pdp-tester maintainers
@@ -149,15 +158,14 @@ jobs:
       - name: Capture PDP container state and logs
         if: always()
         run: |
+          filter="label=pdp-tester.permit.io/managed-by=pdp-tester"
           echo "=== PDP containers (all states) ==="
-          docker ps -a --filter "label=pdp-tester.permit.io/managed-by=pdp-tester" \
-            --format '{{.Names}}\t{{.Status}}' || true
+          docker ps -a --filter "$filter" --format '{{.Names}}\t{{.Status}}' || true
           echo ""
           echo "=== PDP container logs ==="
-          for c in $(docker ps -aq --filter "label=pdp-tester.permit.io/managed-by=pdp-tester"); do
-            name=$(docker inspect --format '{{.Name}}' "$c" | sed 's#^/##')
+          for name in $(docker ps -a --filter "$filter" --format '{{.Names}}'); do
             echo "--- ${name} ---"
-            docker logs "$c" 2>&1 | tail -200 || true
+            docker logs --tail 200 "$name" 2>&1 || true
           done
 
   docker-scout:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-aiohttp>=3.13.3,<4
+# Upper bound <3.14: aiohttp 3.14 changed ClientResponse.__init__ (added a
+# required `stream_writer` kwarg), which the test mock library aioresponses
+# (latest 0.7.9) does not yet pass — breaking the horizon pytests. The >=3.13.3
+# floor keeps the CVE-2025-69223 / 69227 / 69228 / 69229 fixes. Lift the cap
+# once aioresponses ships aiohttp 3.14 support.
+aiohttp>=3.13.3,<3.14
 fastapi>=0.115.6,<1
 Jinja2>=3.1.2,<4
 pydantic[email]>=1.9.1,<2


### PR DESCRIPTION
## Problem

The `pdp-tester` CI job fails at **Start k3d cluster** on every PR:

```
Downloading k3d@v5.4.6 ... curl: (22) The requested URL returned error: 404
Failed to install k3d
```

`AbsaOSS/k3d-action@v2.4.0` defaults to k3d **v5.4.6**, whose GitHub release has no `checksums.txt`. k3d's `install.sh` now SHA256-verifies the downloaded binary against that file, so the download 404s. It's environmental (the job passed on `main` in May) and now blocks the tester on all branches.

## Fix

Switch `pdp-tester` to the tester's **Docker runtime backend** (`--docker`, via `aiodocker`), which runs the PDP as a local container — no k3d / Helm / kubectl. This mirrors pdp-tester's own `pdp-tester-docker` CI job (the runtime the maintainers recommend for CI).

- `pip install -e ".[docker]"` then `python -m pdp_tester --docker --local --tag next --skip-generate`
- `LOCAL_IMAGE=permitio/pdp-v2` pins it to the **locally built** `permitio/pdp-v2:next` image (loaded from the `build-pdp-image` artifact) — nothing pulled from Docker Hub
- Kept `START_TIMEOUT=180` (matching the old Helm setting) + a `docker logs` post-mortem step
- Net: **34 insertions, 62 deletions**

## Verified

Green on the branch where this originated (#318). Job logs show:

```
Using local image: permitio/pdp-v2
Launching 1 PDPs of 1 versions: ['next']
GET /healthy ... 200 OK
All 24 tests passed! 🎉
```

(~2m30s). Split out from #318 so it lands on `main` and applies to all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)