### PR TITLE
feat: add ENFORCE_OPERATIONAL_ROUTE_AUTH rollout toggle (PER-15243)

### DIFF
--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -1,4 +1,6 @@
 import hmac
+import threading
+import time
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
@@ -66,6 +68,47 @@ def enforce_pdp_token(credentials: PdpCredentials = None):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid PDP token")
 
 
+# Rate-limit for the warn-and-allow path of enforce_pdp_token_operational. While
+# ENFORCE_OPERATIONAL_ROUTE_AUTH is off, every unauthenticated request to a governed route would
+# otherwise emit one WARNING - which on the high-QPS /kong decision endpoint floods the synchronous
+# stdout log sink (and adds a blocking write to the request path). Instead we coalesce to one line
+# per route per interval that reports how many would-be rejections were allowed; that count is also
+# the rollout signal - watch it fall to zero, then flip the flag on. The gate runs in a threadpool
+# (it is a sync dependency), so the shared counters are guarded by a plain threading.Lock.
+_OPERATIONAL_WARN_INTERVAL_SECONDS = 60.0
+_operational_warn_lock = threading.Lock()
+# path -> (would-be rejections accumulated since the last emitted line, monotonic time of that emit)
+_operational_warn_state: dict[str, tuple[int, float]] = {}
+
+
+def reset_operational_warn_throttle() -> None:
+    """Clear the throttle state. For tests, whose asserted warnings must not be suppressed by a prior test."""
+    with _operational_warn_lock:
+        _operational_warn_state.clear()
+
+
+def _operational_warn_should_emit(path: str) -> tuple[bool, int]:
+    """Decide whether to emit the warn-and-allow line for ``path`` now, coalescing bursts.
+
+    Returns ``(emit_now, count_since_last_emit)``. Every call counts as one would-be rejection; a
+    line is emitted on the first hit for a path and then at most once per
+    ``_OPERATIONAL_WARN_INTERVAL_SECONDS``, carrying the number of rejections coalesced into it.
+    """
+    now = time.monotonic()
+    with _operational_warn_lock:
+        state = _operational_warn_state.get(path)
+        if state is None:
+            _operational_warn_state[path] = (0, now)
+            return True, 1
+        pending, last_emit = state
+        pending += 1
+        if now - last_emit >= _OPERATIONAL_WARN_INTERVAL_SECONDS:
+            _operational_warn_state[path] = (0, now)
+            return True, pending
+        _operational_warn_state[path] = (pending, last_emit)
+        return False, pending
+
+
 def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials = None):
     """PDP-token gate for the operational routes hardened by PER-15244/PER-15245, with a rollout default.
 
@@ -81,20 +124,25 @@ def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials 
     """
     # Reuse enforce_pdp_token's exact reject logic in one place. When the flag is on, a rejection is
     # honoured (re-raised). When it is off - the rollout default - the rejection is downgraded to
-    # warn-and-allow so no caller breaks while every would-be rejection is still flagged.
+    # warn-and-allow so no caller breaks; every would-be rejection is still counted, and surfaced in a
+    # per-route coalesced warning (see _operational_warn_should_emit) rather than one line per request.
     try:
         enforce_pdp_token(credentials)
     except HTTPException as exc:
         if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
             raise
-        logger.warning(
-            "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowing {method} {path} unauthenticated - it would "
-            "otherwise be rejected ({detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "
-            "token on this route.",
-            method=request.method,
-            path=request.url.path,
-            detail=exc.detail,
-        )
+        emit, coalesced = _operational_warn_should_emit(request.url.path)
+        if emit:
+            logger.warning(
+                "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} unauthenticated request(s) to "
+                "{method} {path} in the last ~{interval}s that would otherwise be rejected (e.g. {detail}). "
+                "Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on this route.",
+                count=coalesced,
+                method=request.method,
+                path=request.url.path,
+                interval=int(_OPERATIONAL_WARN_INTERVAL_SECONDS),
+                detail=exc.detail,
+            )
 
 
 def enforce_pdp_control_key(credentials: PdpCredentials = None):

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -72,9 +72,16 @@ def enforce_pdp_token(credentials: PdpCredentials = None):
 # ENFORCE_OPERATIONAL_ROUTE_AUTH is off, every unauthenticated request to a governed route would
 # otherwise emit one WARNING - which on the high-QPS /kong decision endpoint floods the synchronous
 # stdout log sink (and adds a blocking write to the request path). Instead we coalesce to one line
-# per route per interval that reports how many would-be rejections were allowed; that count is also
-# the rollout signal - watch it fall to zero, then flip the flag on. The gate runs in a threadpool
-# (it is a sync dependency), so the shared counters are guarded by a plain threading.Lock.
+# per route per interval that reports how many would-be rejections were allowed and the real span
+# they cover; that count is also the rollout signal - watch it fall to zero, then flip the flag on.
+# The gate runs in a threadpool (it is a sync dependency), so the shared counters are guarded by a
+# plain threading.Lock. A path's coalesced tail is flushed lazily - only by the next request that
+# arrives past the interval - so between flushes the live count is best-effort; a route that falls
+# idle mid-window strands its tail until the next request or process exit. flush_operational_warn_residuals()
+# (wired into app shutdown in horizon/pdp.py) surfaces that residual on a graceful drain, but a
+# long-lived worker with an idle route still under-reports until traffic resumes, and the count is
+# per-process (N gunicorn workers = N streams) - so treat "the logs went quiet" as best-effort, not
+# proof every caller migrated.
 _OPERATIONAL_WARN_INTERVAL_SECONDS = 60.0
 _operational_warn_lock = threading.Lock()
 # path -> (would-be rejections accumulated since the last emitted line, monotonic time of that emit)
@@ -82,31 +89,75 @@ _operational_warn_state: dict[str, tuple[int, float]] = {}
 
 
 def reset_operational_warn_throttle() -> None:
-    """Clear the throttle state. For tests, whose asserted warnings must not be suppressed by a prior test."""
+    """Clear the process-global throttle state.
+
+    Used by tests so an asserted warning is not suppressed by a warning already logged for the same
+    path in a prior test - the throttle state outlives a single test. Wired as an autouse fixture in
+    the test conftest.
+    """
     with _operational_warn_lock:
         _operational_warn_state.clear()
 
 
-def _operational_warn_should_emit(path: str) -> tuple[bool, int]:
+def _operational_warn_should_emit(path: str) -> tuple[bool, int, float]:
     """Decide whether to emit the warn-and-allow line for ``path`` now, coalescing bursts.
 
-    Returns ``(emit_now, count_since_last_emit)``. Every call counts as one would-be rejection; a
+    Returns ``(emit_now, count, window_seconds)``. Every call counts as one would-be rejection. A
     line is emitted on the first hit for a path and then at most once per
-    ``_OPERATIONAL_WARN_INTERVAL_SECONDS``, carrying the number of rejections coalesced into it.
+    ``_OPERATIONAL_WARN_INTERVAL_SECONDS``; ``count`` is the number of rejections coalesced into the
+    emitted line and ``window_seconds`` is the real span they cover (``now - last_emit``, which can
+    exceed the interval when a route is sparse), so the caller reports the true window rather than a
+    fixed one.
     """
     now = time.monotonic()
     with _operational_warn_lock:
         state = _operational_warn_state.get(path)
         if state is None:
             _operational_warn_state[path] = (0, now)
-            return True, 1
+            return True, 1, 0.0
         pending, last_emit = state
         pending += 1
-        if now - last_emit >= _OPERATIONAL_WARN_INTERVAL_SECONDS:
+        window = now - last_emit
+        if window >= _OPERATIONAL_WARN_INTERVAL_SECONDS:
             _operational_warn_state[path] = (0, now)
-            return True, pending
+            return True, pending, window
         _operational_warn_state[path] = (pending, last_emit)
-        return False, pending
+        return False, pending, window
+
+
+def flush_operational_warn_residuals() -> None:
+    """Emit any coalesced would-be-rejection counts still pending, so an idle route drops no tail.
+
+    The warn-and-allow throttle only flushes a path's coalesced count when a *later* request arrives
+    past the interval (see ``_operational_warn_should_emit``). A route that goes quiet mid-window
+    would otherwise never report the requests coalesced since its last emitted line - and that count
+    is the rollout signal operators watch fall to zero, so it under-reports exactly when traffic is
+    sparse. Wired into app shutdown (``horizon/pdp.py``) so a draining worker surfaces its residual
+    before exit; safe to call at any time and a no-op when nothing is pending.
+
+    Best-effort, not a completeness guarantee: only a *graceful* drain runs this. An ungraceful exit
+    (SIGKILL from the watchdog, ``/_exit``'s ``os._exit``) skips it, and a long-lived healthy worker
+    with an idle route still strands its tail until traffic resumes. Confirm a rollout is complete by
+    the emitted count trending to zero across an interval of live traffic - not by silence.
+    """
+    now = time.monotonic()
+    with _operational_warn_lock:
+        residuals = []
+        for path, (pending, last_emit) in list(_operational_warn_state.items()):
+            if pending > 0:
+                residuals.append((path, pending, now - last_emit))
+                _operational_warn_state[path] = (0, now)
+    for path, pending, window in residuals:
+        logger.warning(
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: flushing {count} further request(s) without a valid "
+            "PDP token (missing or invalid) to {path}, coalesced over the last ~{window}s since the last "
+            "reported line and flushed on shutdown (add to any 'allowed N' line already logged for this "
+            "route to get the true total). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "
+            "token on this route.",
+            count=pending,
+            path=path,
+            window=round(window),
+        )
 
 
 def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials = None):
@@ -131,17 +182,17 @@ def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials 
     except HTTPException as exc:
         if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
             raise
-        emit, coalesced = _operational_warn_should_emit(request.url.path)
+        emit, coalesced, window = _operational_warn_should_emit(request.url.path)
         if emit:
             logger.warning(
                 "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} request(s) without a valid PDP token "
-                "(missing or invalid) to {method} {path} in the last ~{interval}s that would otherwise be "
+                "(missing or invalid) to {method} {path} in the last ~{window}s that would otherwise be "
                 "rejected (e.g. {detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token "
                 "on this route.",
                 count=coalesced,
                 method=request.method,
                 path=request.url.path,
-                interval=int(_OPERATIONAL_WARN_INTERVAL_SECONDS),
+                window=round(window),
                 detail=exc.detail,
             )
 

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -79,14 +79,14 @@ def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials 
     fail-closed route audit recognises auth gates by callable name - a bare ``enforce_pdp_token`` here
     could not carry the conditional behaviour, and an inline lambda would be invisible to the audit.
     """
-    if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
-        enforce_pdp_token(credentials)
-        return
-    # Permissive rollout default: reuse enforce_pdp_token's exact reject logic, but downgrade a
-    # rejection to warn-and-allow so no caller breaks while every would-be rejection is still flagged.
+    # Reuse enforce_pdp_token's exact reject logic in one place. When the flag is on, a rejection is
+    # honoured (re-raised). When it is off - the rollout default - the rejection is downgraded to
+    # warn-and-allow so no caller breaks while every would-be rejection is still flagged.
     try:
         enforce_pdp_token(credentials)
     except HTTPException as exc:
+        if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
+            raise
         logger.warning(
             "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowing {method} {path} unauthenticated - it would "
             "otherwise be rejected ({detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -1,11 +1,8 @@
 import hmac
-import threading
-import time
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from loguru import logger
 
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.startup.api_keys import get_env_api_key
@@ -66,135 +63,6 @@ def enforce_pdp_token(credentials: PdpCredentials = None):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
     if not _token_matches(credentials, get_env_api_key()):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid PDP token")
-
-
-# Rate-limit for the warn-and-allow path of enforce_pdp_token_operational. While
-# ENFORCE_OPERATIONAL_ROUTE_AUTH is off, every unauthenticated request to a governed route would
-# otherwise emit one WARNING - which on the high-QPS /kong decision endpoint floods the synchronous
-# stdout log sink (and adds a blocking write to the request path). Instead we coalesce to one line
-# per route per interval that reports how many would-be rejections were allowed and the real span
-# they cover; that count is also the rollout signal - watch it fall to zero, then flip the flag on.
-# The gate runs in a threadpool (it is a sync dependency), so the shared counters are guarded by a
-# plain threading.Lock. A path's coalesced tail is flushed lazily - only by the next request that
-# arrives past the interval - so between flushes the live count is best-effort; a route that falls
-# idle mid-window strands its tail until the next request or process exit. flush_operational_warn_residuals()
-# (wired into app shutdown in horizon/pdp.py) surfaces that residual on a graceful drain, but a
-# long-lived worker with an idle route still under-reports until traffic resumes, and the count is
-# per-process (N gunicorn workers = N streams) - so treat "the logs went quiet" as best-effort, not
-# proof every caller migrated.
-_OPERATIONAL_WARN_INTERVAL_SECONDS = 60.0
-_operational_warn_lock = threading.Lock()
-# path -> (would-be rejections accumulated since the last emitted line, monotonic time of that emit)
-_operational_warn_state: dict[str, tuple[int, float]] = {}
-
-
-def reset_operational_warn_throttle() -> None:
-    """Clear the process-global throttle state.
-
-    Used by tests so an asserted warning is not suppressed by a warning already logged for the same
-    path in a prior test - the throttle state outlives a single test. Wired as an autouse fixture in
-    the test conftest.
-    """
-    with _operational_warn_lock:
-        _operational_warn_state.clear()
-
-
-def _operational_warn_should_emit(path: str) -> tuple[bool, int, float]:
-    """Decide whether to emit the warn-and-allow line for ``path`` now, coalescing bursts.
-
-    Returns ``(emit_now, count, window_seconds)``. Every call counts as one would-be rejection. A
-    line is emitted on the first hit for a path and then at most once per
-    ``_OPERATIONAL_WARN_INTERVAL_SECONDS``; ``count`` is the number of rejections coalesced into the
-    emitted line and ``window_seconds`` is the real span they cover (``now - last_emit``, which can
-    exceed the interval when a route is sparse), so the caller reports the true window rather than a
-    fixed one.
-    """
-    now = time.monotonic()
-    with _operational_warn_lock:
-        state = _operational_warn_state.get(path)
-        if state is None:
-            _operational_warn_state[path] = (0, now)
-            return True, 1, 0.0
-        pending, last_emit = state
-        pending += 1
-        window = now - last_emit
-        if window >= _OPERATIONAL_WARN_INTERVAL_SECONDS:
-            _operational_warn_state[path] = (0, now)
-            return True, pending, window
-        _operational_warn_state[path] = (pending, last_emit)
-        return False, pending, window
-
-
-def flush_operational_warn_residuals() -> None:
-    """Emit any coalesced would-be-rejection counts still pending, so an idle route drops no tail.
-
-    The warn-and-allow throttle only flushes a path's coalesced count when a *later* request arrives
-    past the interval (see ``_operational_warn_should_emit``). A route that goes quiet mid-window
-    would otherwise never report the requests coalesced since its last emitted line - and that count
-    is the rollout signal operators watch fall to zero, so it under-reports exactly when traffic is
-    sparse. Wired into app shutdown (``horizon/pdp.py``) so a draining worker surfaces its residual
-    before exit; safe to call at any time and a no-op when nothing is pending.
-
-    Best-effort, not a completeness guarantee: only a *graceful* drain runs this. An ungraceful exit
-    (SIGKILL from the watchdog, ``/_exit``'s ``os._exit``) skips it, and a long-lived healthy worker
-    with an idle route still strands its tail until traffic resumes. Confirm a rollout is complete by
-    the emitted count trending to zero across an interval of live traffic - not by silence.
-    """
-    now = time.monotonic()
-    with _operational_warn_lock:
-        residuals = []
-        for path, (pending, last_emit) in list(_operational_warn_state.items()):
-            if pending > 0:
-                residuals.append((path, pending, now - last_emit))
-                _operational_warn_state[path] = (0, now)
-    for path, pending, window in residuals:
-        logger.warning(
-            "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: flushing {count} further request(s) without a valid "
-            "PDP token (missing or invalid) to {path}, coalesced over the last ~{window}s since the last "
-            "reported line and flushed on shutdown (add to any 'allowed N' line already logged for this "
-            "route to get the true total). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "
-            "token on this route.",
-            count=pending,
-            path=path,
-            window=round(window),
-        )
-
-
-def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials = None):
-    """PDP-token gate for the operational routes hardened by PER-15244/PER-15245, with a rollout default.
-
-    Governed by ``ENFORCE_OPERATIONAL_ROUTE_AUTH``. When it is true this is exactly ``enforce_pdp_token``.
-    When it is false - the default, for a safe fleet rollout - a request that would be rejected is allowed
-    through but logged, so callers that don't yet send the PDP token keep working while the logs surface
-    them before enforcement is switched on.
-
-    The flag is read per-request (never captured at import) so a cloud control-plane override takes
-    effect and tests can toggle it. Kept as a distinct, named module-level function because the
-    fail-closed route audit recognises auth gates by callable name - a bare ``enforce_pdp_token`` here
-    could not carry the conditional behaviour, and an inline lambda would be invisible to the audit.
-    """
-    # Reuse enforce_pdp_token's exact reject logic in one place. When the flag is on, a rejection is
-    # honoured (re-raised). When it is off - the rollout default - the rejection is downgraded to
-    # warn-and-allow so no caller breaks; every would-be rejection is still counted, and surfaced in a
-    # per-route coalesced warning (see _operational_warn_should_emit) rather than one line per request.
-    try:
-        enforce_pdp_token(credentials)
-    except HTTPException as exc:
-        if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
-            raise
-        emit, coalesced, window = _operational_warn_should_emit(request.url.path)
-        if emit:
-            logger.warning(
-                "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} request(s) without a valid PDP token "
-                "(missing or invalid) to {method} {path} in the last ~{window}s that would otherwise be "
-                "rejected (e.g. {detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token "
-                "on this route.",
-                count=coalesced,
-                method=request.method,
-                path=request.url.path,
-                window=round(window),
-                detail=exc.detail,
-            )
 
 
 def enforce_pdp_control_key(credentials: PdpCredentials = None):

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -1,8 +1,9 @@
 import hmac
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from opal_client.logger import logger
 
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.startup.api_keys import get_env_api_key
@@ -63,6 +64,37 @@ def enforce_pdp_token(credentials: PdpCredentials = None):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
     if not _token_matches(credentials, get_env_api_key()):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid PDP token")
+
+
+def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials = None):
+    """PDP-token gate for the operational routes hardened by PER-15244/PER-15245, with a rollout default.
+
+    Governed by ``ENFORCE_OPERATIONAL_ROUTE_AUTH``. When it is true this is exactly ``enforce_pdp_token``.
+    When it is false - the default, for a safe fleet rollout - a request that would be rejected is allowed
+    through but logged, so callers that don't yet send the PDP token keep working while the logs surface
+    them before enforcement is switched on.
+
+    The flag is read per-request (never captured at import) so a cloud control-plane override takes
+    effect and tests can toggle it. Kept as a distinct, named module-level function because the
+    fail-closed route audit recognises auth gates by callable name - a bare ``enforce_pdp_token`` here
+    could not carry the conditional behaviour, and an inline lambda would be invisible to the audit.
+    """
+    if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
+        enforce_pdp_token(credentials)
+        return
+    # Permissive rollout default: reuse enforce_pdp_token's exact reject logic, but downgrade a
+    # rejection to warn-and-allow so no caller breaks while every would-be rejection is still flagged.
+    try:
+        enforce_pdp_token(credentials)
+    except HTTPException as exc:
+        logger.warning(
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowing {method} {path} unauthenticated - it would "
+            "otherwise be rejected ({detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "
+            "token on this route.",
+            method=request.method,
+            path=request.url.path,
+            detail=exc.detail,
+        )
 
 
 def enforce_pdp_control_key(credentials: PdpCredentials = None):

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -1,8 +1,11 @@
 import hmac
+import threading
+import time
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from loguru import logger
 
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.startup.api_keys import get_env_api_key
@@ -63,6 +66,135 @@ def enforce_pdp_token(credentials: PdpCredentials = None):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
     if not _token_matches(credentials, get_env_api_key()):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid PDP token")
+
+
+# Rate-limit for the warn-and-allow path of enforce_pdp_token_operational. While
+# ENFORCE_OPERATIONAL_ROUTE_AUTH is off, every unauthenticated request to a governed route would
+# otherwise emit one WARNING - which on the high-QPS /kong decision endpoint floods the synchronous
+# stdout log sink (and adds a blocking write to the request path). Instead we coalesce to one line
+# per route per interval that reports how many would-be rejections were allowed and the real span
+# they cover; that count is also the rollout signal - watch it fall to zero, then flip the flag on.
+# The gate runs in a threadpool (it is a sync dependency), so the shared counters are guarded by a
+# plain threading.Lock. A path's coalesced tail is flushed lazily - only by the next request that
+# arrives past the interval - so between flushes the live count is best-effort; a route that falls
+# idle mid-window strands its tail until the next request or process exit. flush_operational_warn_residuals()
+# (wired into app shutdown in horizon/pdp.py) surfaces that residual on a graceful drain, but a
+# long-lived worker with an idle route still under-reports until traffic resumes, and the count is
+# per-process (N gunicorn workers = N streams) - so treat "the logs went quiet" as best-effort, not
+# proof every caller migrated.
+_OPERATIONAL_WARN_INTERVAL_SECONDS = 60.0
+_operational_warn_lock = threading.Lock()
+# path -> (would-be rejections accumulated since the last emitted line, monotonic time of that emit)
+_operational_warn_state: dict[str, tuple[int, float]] = {}
+
+
+def reset_operational_warn_throttle() -> None:
+    """Clear the process-global throttle state.
+
+    Used by tests so an asserted warning is not suppressed by a warning already logged for the same
+    path in a prior test - the throttle state outlives a single test. Wired as an autouse fixture in
+    the test conftest.
+    """
+    with _operational_warn_lock:
+        _operational_warn_state.clear()
+
+
+def _operational_warn_should_emit(path: str) -> tuple[bool, int, float]:
+    """Decide whether to emit the warn-and-allow line for ``path`` now, coalescing bursts.
+
+    Returns ``(emit_now, count, window_seconds)``. Every call counts as one would-be rejection. A
+    line is emitted on the first hit for a path and then at most once per
+    ``_OPERATIONAL_WARN_INTERVAL_SECONDS``; ``count`` is the number of rejections coalesced into the
+    emitted line and ``window_seconds`` is the real span they cover (``now - last_emit``, which can
+    exceed the interval when a route is sparse), so the caller reports the true window rather than a
+    fixed one.
+    """
+    now = time.monotonic()
+    with _operational_warn_lock:
+        state = _operational_warn_state.get(path)
+        if state is None:
+            _operational_warn_state[path] = (0, now)
+            return True, 1, 0.0
+        pending, last_emit = state
+        pending += 1
+        window = now - last_emit
+        if window >= _OPERATIONAL_WARN_INTERVAL_SECONDS:
+            _operational_warn_state[path] = (0, now)
+            return True, pending, window
+        _operational_warn_state[path] = (pending, last_emit)
+        return False, pending, window
+
+
+def flush_operational_warn_residuals() -> None:
+    """Emit any coalesced would-be-rejection counts still pending, so an idle route drops no tail.
+
+    The warn-and-allow throttle only flushes a path's coalesced count when a *later* request arrives
+    past the interval (see ``_operational_warn_should_emit``). A route that goes quiet mid-window
+    would otherwise never report the requests coalesced since its last emitted line - and that count
+    is the rollout signal operators watch fall to zero, so it under-reports exactly when traffic is
+    sparse. Wired into app shutdown (``horizon/pdp.py``) so a draining worker surfaces its residual
+    before exit; safe to call at any time and a no-op when nothing is pending.
+
+    Best-effort, not a completeness guarantee: only a *graceful* drain runs this. An ungraceful exit
+    (SIGKILL from the watchdog, ``/_exit``'s ``os._exit``) skips it, and a long-lived healthy worker
+    with an idle route still strands its tail until traffic resumes. Confirm a rollout is complete by
+    the emitted count trending to zero across an interval of live traffic - not by silence.
+    """
+    now = time.monotonic()
+    with _operational_warn_lock:
+        residuals = []
+        for path, (pending, last_emit) in list(_operational_warn_state.items()):
+            if pending > 0:
+                residuals.append((path, pending, now - last_emit))
+                _operational_warn_state[path] = (0, now)
+    for path, pending, window in residuals:
+        logger.warning(
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: flushing {count} further request(s) without a valid "
+            "PDP token (missing or invalid) to {path}, coalesced over the last ~{window}s since the last "
+            "reported line and flushed on shutdown (add to any 'allowed N' line already logged for this "
+            "route to get the true total). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP "
+            "token on this route.",
+            count=pending,
+            path=path,
+            window=round(window),
+        )
+
+
+def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials = None):
+    """PDP-token gate for the operational routes hardened by PER-15244/PER-15245, with a rollout default.
+
+    Governed by ``ENFORCE_OPERATIONAL_ROUTE_AUTH``. When it is true this is exactly ``enforce_pdp_token``.
+    When it is false - the default, for a safe fleet rollout - a request that would be rejected is allowed
+    through but logged, so callers that don't yet send the PDP token keep working while the logs surface
+    them before enforcement is switched on.
+
+    The flag is read per-request (never captured at import) so a cloud control-plane override takes
+    effect and tests can toggle it. Kept as a distinct, named module-level function because the
+    fail-closed route audit recognises auth gates by callable name - a bare ``enforce_pdp_token`` here
+    could not carry the conditional behaviour, and an inline lambda would be invisible to the audit.
+    """
+    # Reuse enforce_pdp_token's exact reject logic in one place. When the flag is on, a rejection is
+    # honoured (re-raised). When it is off - the rollout default - the rejection is downgraded to
+    # warn-and-allow so no caller breaks; every would-be rejection is still counted, and surfaced in a
+    # per-route coalesced warning (see _operational_warn_should_emit) rather than one line per request.
+    try:
+        enforce_pdp_token(credentials)
+    except HTTPException as exc:
+        if sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
+            raise
+        emit, coalesced, window = _operational_warn_should_emit(request.url.path)
+        if emit:
+            logger.warning(
+                "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} request(s) without a valid PDP token "
+                "(missing or invalid) to {method} {path} in the last ~{window}s that would otherwise be "
+                "rejected (e.g. {detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token "
+                "on this route.",
+                count=coalesced,
+                method=request.method,
+                path=request.url.path,
+                window=round(window),
+                detail=exc.detail,
+            )
 
 
 def enforce_pdp_control_key(credentials: PdpCredentials = None):

--- a/horizon/authentication.py
+++ b/horizon/authentication.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from opal_client.logger import logger
+from loguru import logger
 
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.startup.api_keys import get_env_api_key
@@ -134,9 +134,10 @@ def enforce_pdp_token_operational(request: Request, credentials: PdpCredentials 
         emit, coalesced = _operational_warn_should_emit(request.url.path)
         if emit:
             logger.warning(
-                "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} unauthenticated request(s) to "
-                "{method} {path} in the last ~{interval}s that would otherwise be rejected (e.g. {detail}). "
-                "Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on this route.",
+                "ENFORCE_OPERATIONAL_ROUTE_AUTH is off: allowed {count} request(s) without a valid PDP token "
+                "(missing or invalid) to {method} {path} in the last ~{interval}s that would otherwise be "
+                "rejected (e.g. {detail}). Set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token "
+                "on this route.",
                 count=coalesced,
                 method=request.method,
                 path=request.url.path,

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -262,18 +262,6 @@ class SidecarConfig(Confi):
     # enables debug ouptut for the Kong integration endpoint
     KONG_INTEGRATION_DEBUG = confi.bool("KONG_INTEGRATION_DEBUG", False)
 
-    ENFORCE_OPERATIONAL_ROUTE_AUTH = confi.bool(
-        "ENFORCE_OPERATIONAL_ROUTE_AUTH",
-        False,
-        description="When true, enforce the PDP token on the operational routes hardened by the auth-hardening "
-        "rollout: the update-trigger routes (/policy-updater/trigger, /data-updater/trigger, /update_policy, "
-        "/update_policy_data) and the /kong decision endpoint. Defaults to FALSE for a safe fleet rollout: those "
-        "routes accept unauthenticated requests and only LOG the ones that would be rejected, so callers that do not "
-        "yet send the token keep working while you watch the logs. Flip to true (per-fleet via the cloud control "
-        "plane, or PDP_ENFORCE_OPERATIONAL_ROUTE_AUTH) once every caller sends the token. Every other PDP route is "
-        "always enforced regardless of this flag.",
-    )
-
     LOCAL_FACTS_WAIT_TIMEOUT = confi.float(
         "LOCAL_FACTS_WAIT_TIMEOUT",
         10,

--- a/horizon/config.py
+++ b/horizon/config.py
@@ -262,6 +262,18 @@ class SidecarConfig(Confi):
     # enables debug ouptut for the Kong integration endpoint
     KONG_INTEGRATION_DEBUG = confi.bool("KONG_INTEGRATION_DEBUG", False)
 
+    ENFORCE_OPERATIONAL_ROUTE_AUTH = confi.bool(
+        "ENFORCE_OPERATIONAL_ROUTE_AUTH",
+        False,
+        description="When true, enforce the PDP token on the operational routes hardened by the auth-hardening "
+        "rollout: the update-trigger routes (/policy-updater/trigger, /data-updater/trigger, /update_policy, "
+        "/update_policy_data) and the /kong decision endpoint. Defaults to FALSE for a safe fleet rollout: those "
+        "routes accept unauthenticated requests and only LOG the ones that would be rejected, so callers that do not "
+        "yet send the token keep working while you watch the logs. Flip to true (per-fleet via the cloud control "
+        "plane, or PDP_ENFORCE_OPERATIONAL_ROUTE_AUTH) once every caller sends the token. Every other PDP route is "
+        "always enforced regardless of this flag.",
+    )
+
     LOCAL_FACTS_WAIT_TIMEOUT = confi.float(
         "LOCAL_FACTS_WAIT_TIMEOUT",
         10,

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -277,12 +277,6 @@ def init_enforcer_health_router():
 def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noqa: C901
     policy_store = policy_store or DEFAULT_POLICY_STORE_GETTER()
     router = APIRouter()
-    # /kong lives on its own router so it can be mounted under the ENFORCE_OPERATIONAL_ROUTE_AUTH-aware
-    # gate (enforce_pdp_token_operational) while every other enforcer route keeps the plain
-    # enforce_pdp_token gate. Same closure as the rest of the enforcer routes: /kong's handler closes
-    # over kong_routes_table and the nested _is_allowed helper, so a router split here avoids a much
-    # larger refactor. Mounted separately in PermitPDP._configure_api_routes.
-    kong_router = APIRouter()
     if sidecar_config.KONG_INTEGRATION:
         with Path(KONG_ROUTES_TABLE_FILE).open() as f:
             kong_routes_table_raw = json.load(f)
@@ -549,7 +543,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
             )
             return {"allow": False, "result": False}
 
-    @kong_router.post(
+    @router.post(
         "/kong",
         response_model=KongAuthorizationResult,
         status_code=status.HTTP_200_OK,
@@ -626,7 +620,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
             )
             return {"allow": False, "result": False}
 
-    return router, kong_router
+    return router
 
 
 def _extract_regex_attributes(pattern: str, url: str) -> dict:

--- a/horizon/enforcer/api.py
+++ b/horizon/enforcer/api.py
@@ -277,6 +277,12 @@ def init_enforcer_health_router():
 def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noqa: C901
     policy_store = policy_store or DEFAULT_POLICY_STORE_GETTER()
     router = APIRouter()
+    # /kong lives on its own router so it can be mounted under the ENFORCE_OPERATIONAL_ROUTE_AUTH-aware
+    # gate (enforce_pdp_token_operational) while every other enforcer route keeps the plain
+    # enforce_pdp_token gate. Same closure as the rest of the enforcer routes: /kong's handler closes
+    # over kong_routes_table and the nested _is_allowed helper, so a router split here avoids a much
+    # larger refactor. Mounted separately in PermitPDP._configure_api_routes.
+    kong_router = APIRouter()
     if sidecar_config.KONG_INTEGRATION:
         with Path(KONG_ROUTES_TABLE_FILE).open() as f:
             kong_routes_table_raw = json.load(f)
@@ -543,7 +549,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
             )
             return {"allow": False, "result": False}
 
-    @router.post(
+    @kong_router.post(
         "/kong",
         response_model=KongAuthorizationResult,
         status_code=status.HTTP_200_OK,
@@ -620,7 +626,7 @@ def init_enforcer_api_router(policy_store: BasePolicyStoreClient = None):  # noq
             )
             return {"allow": False, "result": False}
 
-    return router
+    return router, kong_router
 
 
 def _extract_regex_attributes(pattern: str, url: str) -> dict:

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -26,7 +26,11 @@ from opal_common.fetcher.providers.http_fetch_provider import (
 from opal_common.logging_utils.formatter import Formatter
 from scalar_fastapi import get_scalar_api_reference
 
-from horizon.authentication import enforce_pdp_token, enforce_pdp_token_operational
+from horizon.authentication import (
+    enforce_pdp_token,
+    enforce_pdp_token_operational,
+    flush_operational_warn_residuals,
+)
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.connectivity.api import init_connectivity_router
 from horizon.enforcer.api import init_enforcer_api_router, init_enforcer_health_router, stats_manager
@@ -568,6 +572,11 @@ class PermitPDP:
         # High-signal warning while ENFORCE_OPERATIONAL_ROUTE_AUTH is off (the rollout default) and
         # the update-trigger and /kong routes accept unauthenticated requests.
         _warn_if_operational_route_auth_disabled()
+        # The per-request warn-and-allow throttle only flushes a route's coalesced would-be-rejection
+        # count when a later request arrives past the interval; flush any residual on a graceful drain
+        # so an idle route's tail is surfaced rather than stranded. Best-effort: an ungraceful exit
+        # (watchdog SIGKILL, /_exit's os._exit) skips this - see flush_operational_warn_residuals (PER-15243).
+        app.on_event("shutdown")(flush_operational_warn_residuals)
 
     @property
     def app(self):

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -26,7 +26,11 @@ from opal_common.fetcher.providers.http_fetch_provider import (
 from opal_common.logging_utils.formatter import Formatter
 from scalar_fastapi import get_scalar_api_reference
 
-from horizon.authentication import enforce_pdp_token
+from horizon.authentication import (
+    enforce_pdp_token,
+    enforce_pdp_token_operational,
+    flush_operational_warn_residuals,
+)
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.connectivity.api import init_connectivity_router
 from horizon.enforcer.api import init_enforcer_api_router, init_enforcer_health_router, stats_manager
@@ -108,28 +112,32 @@ OPAL_TRIGGER_ROUTE_PATHS: frozenset[str] = frozenset({"/policy-updater/trigger",
 
 
 def _gate_opal_trigger_routes(app: FastAPI) -> None:
-    """Inject ``Depends(enforce_pdp_token)`` into the OPAL-mounted trigger routes.
+    """Inject ``Depends(enforce_pdp_token_operational)`` into the OPAL-mounted trigger routes.
 
     OpalClient mounts ``POST /policy-updater/trigger`` and ``POST /data-updater/trigger``
     on the app before ``PermitPDP`` gains control (opal_client.client._configure_api_routes),
     so the include_router-level dependencies used for every PDP-owned router cannot reach
-    them. We inject the standard PDP-token dependency into the already-mounted route objects
-    instead, mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py):
-    insert a parameterless sub-dependant at the head of ``route.dependant.dependencies``.
+    them. We inject the PDP-token dependency into the already-mounted route objects instead,
+    mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py): insert a
+    parameterless sub-dependant at the head of ``route.dependant.dependencies``.
+
+    The gate is the operational wrapper, so ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` governs these routes
+    like the sibling operational routes: unauthenticated-but-logged by default, enforced when set.
 
     The Dependant is mutated IN PLACE - the route's request handler closes over that exact
     object, so the check is enforced on every request; do NOT reassign ``route.dependant``.
-    ``enforce_pdp_token`` only reads a header, so the route's body field needs no rebuild.
+    ``enforce_pdp_token_operational`` only reads the header and request, so the route's body field
+    needs no rebuild.
 
     Fails loud if a target route is missing (e.g. an OPAL upgrade renamed it): a silently
-    skipped injection would leave an update-trigger endpoint unauthenticated.
+    skipped injection would leave an update-trigger endpoint ungated even when enforcement is on.
     """
     gated: set[str] = set()
     for route in app.routes:
         if isinstance(route, APIRoute) and route.path in OPAL_TRIGGER_ROUTE_PATHS:
             route.dependant.dependencies.insert(
                 0,
-                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token), path=route.path_format),
+                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token_operational), path=route.path_format),
             )
             gated.add(route.path)
 
@@ -141,6 +149,23 @@ def _gate_opal_trigger_routes(app: FastAPI) -> None:
             ", ".join(sorted(missing)),
         )
         raise SystemExit(GUNICORN_EXIT_APP)
+
+
+def _warn_if_operational_route_auth_disabled() -> None:
+    """Warn when ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` is off and the operational routes accept unauthenticated calls.
+
+    This is the safe-rollout default (see SidecarConfig.ENFORCE_OPERATIONAL_ROUTE_AUTH): the token is not
+    enforced on the update-trigger routes or /kong, only logged. Surfaced at startup as well as per-request
+    so a fleet still in the permissive rollout phase stays visible; flip the flag on once every caller sends
+    the token.
+    """
+    if not sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
+        logger.warning(
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF: the update-trigger routes (/policy-updater/trigger, "
+            "/data-updater/trigger, /update_policy, /update_policy_data) and /kong accept requests WITHOUT "
+            "a valid PDP token (missing or invalid) - would-be rejections are only logged. This is the safe "
+            "fleet-rollout default; set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on these routes."
+        )
 
 
 def _warn_if_opal_verifier_disabled(opal_client: OpalClient) -> None:
@@ -447,7 +472,7 @@ class PermitPDP:
         app.on_event("shutdown")(stats_manager.stop_tasks)
 
         enforcer_health_router = init_enforcer_health_router()
-        enforcer_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
+        enforcer_router, kong_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
         local_router = init_local_cache_api_router(policy_store=self._opal.policy_store)
         # Init system router
         system_router = init_system_api_router()
@@ -459,6 +484,14 @@ class PermitPDP:
             enforcer_router,
             tags=["Authorization API"],
             dependencies=[Depends(enforce_pdp_token)],
+        )
+        # /kong is gated with the operational wrapper so ENFORCE_OPERATIONAL_ROUTE_AUTH governs it
+        # during a fleet rollout (Kong's OPA plugin may not yet forward the PDP token) without
+        # touching the rest of the enforcer router.
+        app.include_router(
+            kong_router,
+            tags=["Authorization API"],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
 
         app.include_router(
@@ -498,11 +531,13 @@ class PermitPDP:
             )
 
         # TODO: remove this when clients update sdk version (legacy routes)
+        # Gated with the operational wrapper: these are aliases of the OPAL trigger routes, so they
+        # follow the same ENFORCE_OPERATIONAL_ROUTE_AUTH rollout default.
         @app.post(
             "/update_policy",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token)],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
         async def legacy_trigger_policy_update():
             logger.info("triggered policy update from api (legacy route)")
@@ -515,7 +550,7 @@ class PermitPDP:
             "/update_policy_data",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token)],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
         async def legacy_trigger_data_update():
             logger.info("triggered policy data update from api (legacy route)")
@@ -534,6 +569,14 @@ class PermitPDP:
         # High-signal warning if the OPAL-authenticated routes are left open by a disabled
         # verifier (must never happen in a managed PDP).
         _warn_if_opal_verifier_disabled(self._opal)
+        # High-signal warning while ENFORCE_OPERATIONAL_ROUTE_AUTH is off (the rollout default) and
+        # the update-trigger and /kong routes accept unauthenticated requests.
+        _warn_if_operational_route_auth_disabled()
+        # The per-request warn-and-allow throttle only flushes a route's coalesced would-be-rejection
+        # count when a later request arrives past the interval; flush any residual on a graceful drain
+        # so an idle route's tail is surfaced rather than stranded. Best-effort: an ungraceful exit
+        # (watchdog SIGKILL, /_exit's os._exit) skips this - see flush_operational_warn_residuals (PER-15243).
+        app.on_event("shutdown")(flush_operational_warn_residuals)
 
     @property
     def app(self):

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -26,7 +26,7 @@ from opal_common.fetcher.providers.http_fetch_provider import (
 from opal_common.logging_utils.formatter import Formatter
 from scalar_fastapi import get_scalar_api_reference
 
-from horizon.authentication import enforce_pdp_token
+from horizon.authentication import enforce_pdp_token, enforce_pdp_token_operational
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.connectivity.api import init_connectivity_router
 from horizon.enforcer.api import init_enforcer_api_router, init_enforcer_health_router, stats_manager
@@ -108,28 +108,32 @@ OPAL_TRIGGER_ROUTE_PATHS: frozenset[str] = frozenset({"/policy-updater/trigger",
 
 
 def _gate_opal_trigger_routes(app: FastAPI) -> None:
-    """Inject ``Depends(enforce_pdp_token)`` into the OPAL-mounted trigger routes.
+    """Inject ``Depends(enforce_pdp_token_operational)`` into the OPAL-mounted trigger routes.
 
     OpalClient mounts ``POST /policy-updater/trigger`` and ``POST /data-updater/trigger``
     on the app before ``PermitPDP`` gains control (opal_client.client._configure_api_routes),
     so the include_router-level dependencies used for every PDP-owned router cannot reach
-    them. We inject the standard PDP-token dependency into the already-mounted route objects
-    instead, mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py):
-    insert a parameterless sub-dependant at the head of ``route.dependant.dependencies``.
+    them. We inject the PDP-token dependency into the already-mounted route objects instead,
+    mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py): insert a
+    parameterless sub-dependant at the head of ``route.dependant.dependencies``.
+
+    The gate is the operational wrapper, so ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` governs these routes
+    like the sibling operational routes: unauthenticated-but-logged by default, enforced when set.
 
     The Dependant is mutated IN PLACE - the route's request handler closes over that exact
     object, so the check is enforced on every request; do NOT reassign ``route.dependant``.
-    ``enforce_pdp_token`` only reads a header, so the route's body field needs no rebuild.
+    ``enforce_pdp_token_operational`` only reads the header and request, so the route's body field
+    needs no rebuild.
 
     Fails loud if a target route is missing (e.g. an OPAL upgrade renamed it): a silently
-    skipped injection would leave an update-trigger endpoint unauthenticated.
+    skipped injection would leave an update-trigger endpoint ungated even when enforcement is on.
     """
     gated: set[str] = set()
     for route in app.routes:
         if isinstance(route, APIRoute) and route.path in OPAL_TRIGGER_ROUTE_PATHS:
             route.dependant.dependencies.insert(
                 0,
-                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token), path=route.path_format),
+                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token_operational), path=route.path_format),
             )
             gated.add(route.path)
 
@@ -141,6 +145,23 @@ def _gate_opal_trigger_routes(app: FastAPI) -> None:
             ", ".join(sorted(missing)),
         )
         raise SystemExit(GUNICORN_EXIT_APP)
+
+
+def _warn_if_operational_route_auth_disabled() -> None:
+    """Warn when ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` is off and the operational routes accept unauthenticated calls.
+
+    This is the safe-rollout default (see SidecarConfig.ENFORCE_OPERATIONAL_ROUTE_AUTH): the token is not
+    enforced on the update-trigger routes or /kong, only logged. Surfaced at startup as well as per-request
+    so a fleet still in the permissive rollout phase stays visible; flip the flag on once every caller sends
+    the token.
+    """
+    if not sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
+        logger.warning(
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF: the update-trigger routes (/policy-updater/trigger, "
+            "/data-updater/trigger, /update_policy, /update_policy_data) and /kong accept UNAUTHENTICATED "
+            "requests - would-be rejections are only logged. This is the safe fleet-rollout default; set "
+            "ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on these routes."
+        )
 
 
 def _warn_if_opal_verifier_disabled(opal_client: OpalClient) -> None:
@@ -447,7 +468,7 @@ class PermitPDP:
         app.on_event("shutdown")(stats_manager.stop_tasks)
 
         enforcer_health_router = init_enforcer_health_router()
-        enforcer_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
+        enforcer_router, kong_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
         local_router = init_local_cache_api_router(policy_store=self._opal.policy_store)
         # Init system router
         system_router = init_system_api_router()
@@ -459,6 +480,14 @@ class PermitPDP:
             enforcer_router,
             tags=["Authorization API"],
             dependencies=[Depends(enforce_pdp_token)],
+        )
+        # /kong is gated with the operational wrapper so ENFORCE_OPERATIONAL_ROUTE_AUTH governs it
+        # during a fleet rollout (Kong's OPA plugin may not yet forward the PDP token) without
+        # touching the rest of the enforcer router.
+        app.include_router(
+            kong_router,
+            tags=["Authorization API"],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
 
         app.include_router(
@@ -498,11 +527,13 @@ class PermitPDP:
             )
 
         # TODO: remove this when clients update sdk version (legacy routes)
+        # Gated with the operational wrapper: these are aliases of the OPAL trigger routes, so they
+        # follow the same ENFORCE_OPERATIONAL_ROUTE_AUTH rollout default.
         @app.post(
             "/update_policy",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token)],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
         async def legacy_trigger_policy_update():
             logger.info("triggered policy update from api (legacy route)")
@@ -515,7 +546,7 @@ class PermitPDP:
             "/update_policy_data",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token)],
+            dependencies=[Depends(enforce_pdp_token_operational)],
         )
         async def legacy_trigger_data_update():
             logger.info("triggered policy data update from api (legacy route)")
@@ -534,6 +565,9 @@ class PermitPDP:
         # High-signal warning if the OPAL-authenticated routes are left open by a disabled
         # verifier (must never happen in a managed PDP).
         _warn_if_opal_verifier_disabled(self._opal)
+        # High-signal warning while ENFORCE_OPERATIONAL_ROUTE_AUTH is off (the rollout default) and
+        # the update-trigger and /kong routes accept unauthenticated requests.
+        _warn_if_operational_route_auth_disabled()
 
     @property
     def app(self):

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -26,11 +26,7 @@ from opal_common.fetcher.providers.http_fetch_provider import (
 from opal_common.logging_utils.formatter import Formatter
 from scalar_fastapi import get_scalar_api_reference
 
-from horizon.authentication import (
-    enforce_pdp_token,
-    enforce_pdp_token_operational,
-    flush_operational_warn_residuals,
-)
+from horizon.authentication import enforce_pdp_token
 from horizon.config import MOCK_API_KEY, sidecar_config
 from horizon.connectivity.api import init_connectivity_router
 from horizon.enforcer.api import init_enforcer_api_router, init_enforcer_health_router, stats_manager
@@ -112,32 +108,28 @@ OPAL_TRIGGER_ROUTE_PATHS: frozenset[str] = frozenset({"/policy-updater/trigger",
 
 
 def _gate_opal_trigger_routes(app: FastAPI) -> None:
-    """Inject ``Depends(enforce_pdp_token_operational)`` into the OPAL-mounted trigger routes.
+    """Inject ``Depends(enforce_pdp_token)`` into the OPAL-mounted trigger routes.
 
     OpalClient mounts ``POST /policy-updater/trigger`` and ``POST /data-updater/trigger``
     on the app before ``PermitPDP`` gains control (opal_client.client._configure_api_routes),
     so the include_router-level dependencies used for every PDP-owned router cannot reach
-    them. We inject the PDP-token dependency into the already-mounted route objects instead,
-    mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py): insert a
-    parameterless sub-dependant at the head of ``route.dependant.dependencies``.
-
-    The gate is the operational wrapper, so ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` governs these routes
-    like the sibling operational routes: unauthenticated-but-logged by default, enforced when set.
+    them. We inject the standard PDP-token dependency into the already-mounted route objects
+    instead, mirroring what FastAPI itself does at ``APIRoute.__init__`` (fastapi/routing.py):
+    insert a parameterless sub-dependant at the head of ``route.dependant.dependencies``.
 
     The Dependant is mutated IN PLACE - the route's request handler closes over that exact
     object, so the check is enforced on every request; do NOT reassign ``route.dependant``.
-    ``enforce_pdp_token_operational`` only reads the header and request, so the route's body field
-    needs no rebuild.
+    ``enforce_pdp_token`` only reads a header, so the route's body field needs no rebuild.
 
     Fails loud if a target route is missing (e.g. an OPAL upgrade renamed it): a silently
-    skipped injection would leave an update-trigger endpoint ungated even when enforcement is on.
+    skipped injection would leave an update-trigger endpoint unauthenticated.
     """
     gated: set[str] = set()
     for route in app.routes:
         if isinstance(route, APIRoute) and route.path in OPAL_TRIGGER_ROUTE_PATHS:
             route.dependant.dependencies.insert(
                 0,
-                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token_operational), path=route.path_format),
+                get_parameterless_sub_dependant(depends=Depends(enforce_pdp_token), path=route.path_format),
             )
             gated.add(route.path)
 
@@ -149,23 +141,6 @@ def _gate_opal_trigger_routes(app: FastAPI) -> None:
             ", ".join(sorted(missing)),
         )
         raise SystemExit(GUNICORN_EXIT_APP)
-
-
-def _warn_if_operational_route_auth_disabled() -> None:
-    """Warn when ``ENFORCE_OPERATIONAL_ROUTE_AUTH`` is off and the operational routes accept unauthenticated calls.
-
-    This is the safe-rollout default (see SidecarConfig.ENFORCE_OPERATIONAL_ROUTE_AUTH): the token is not
-    enforced on the update-trigger routes or /kong, only logged. Surfaced at startup as well as per-request
-    so a fleet still in the permissive rollout phase stays visible; flip the flag on once every caller sends
-    the token.
-    """
-    if not sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
-        logger.warning(
-            "ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF: the update-trigger routes (/policy-updater/trigger, "
-            "/data-updater/trigger, /update_policy, /update_policy_data) and /kong accept requests WITHOUT "
-            "a valid PDP token (missing or invalid) - would-be rejections are only logged. This is the safe "
-            "fleet-rollout default; set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on these routes."
-        )
 
 
 def _warn_if_opal_verifier_disabled(opal_client: OpalClient) -> None:
@@ -472,7 +447,7 @@ class PermitPDP:
         app.on_event("shutdown")(stats_manager.stop_tasks)
 
         enforcer_health_router = init_enforcer_health_router()
-        enforcer_router, kong_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
+        enforcer_router = init_enforcer_api_router(policy_store=self._opal.policy_store)
         local_router = init_local_cache_api_router(policy_store=self._opal.policy_store)
         # Init system router
         system_router = init_system_api_router()
@@ -484,14 +459,6 @@ class PermitPDP:
             enforcer_router,
             tags=["Authorization API"],
             dependencies=[Depends(enforce_pdp_token)],
-        )
-        # /kong is gated with the operational wrapper so ENFORCE_OPERATIONAL_ROUTE_AUTH governs it
-        # during a fleet rollout (Kong's OPA plugin may not yet forward the PDP token) without
-        # touching the rest of the enforcer router.
-        app.include_router(
-            kong_router,
-            tags=["Authorization API"],
-            dependencies=[Depends(enforce_pdp_token_operational)],
         )
 
         app.include_router(
@@ -531,13 +498,11 @@ class PermitPDP:
             )
 
         # TODO: remove this when clients update sdk version (legacy routes)
-        # Gated with the operational wrapper: these are aliases of the OPAL trigger routes, so they
-        # follow the same ENFORCE_OPERATIONAL_ROUTE_AUTH rollout default.
         @app.post(
             "/update_policy",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token_operational)],
+            dependencies=[Depends(enforce_pdp_token)],
         )
         async def legacy_trigger_policy_update():
             logger.info("triggered policy update from api (legacy route)")
@@ -550,7 +515,7 @@ class PermitPDP:
             "/update_policy_data",
             status_code=status.HTTP_200_OK,
             include_in_schema=False,
-            dependencies=[Depends(enforce_pdp_token_operational)],
+            dependencies=[Depends(enforce_pdp_token)],
         )
         async def legacy_trigger_data_update():
             logger.info("triggered policy data update from api (legacy route)")
@@ -569,14 +534,6 @@ class PermitPDP:
         # High-signal warning if the OPAL-authenticated routes are left open by a disabled
         # verifier (must never happen in a managed PDP).
         _warn_if_opal_verifier_disabled(self._opal)
-        # High-signal warning while ENFORCE_OPERATIONAL_ROUTE_AUTH is off (the rollout default) and
-        # the update-trigger and /kong routes accept unauthenticated requests.
-        _warn_if_operational_route_auth_disabled()
-        # The per-request warn-and-allow throttle only flushes a route's coalesced would-be-rejection
-        # count when a later request arrives past the interval; flush any residual on a graceful drain
-        # so an idle route's tail is surfaced rather than stranded. Best-effort: an ungraceful exit
-        # (watchdog SIGKILL, /_exit's os._exit) skips this - see flush_operational_warn_residuals (PER-15243).
-        app.on_event("shutdown")(flush_operational_warn_residuals)
 
     @property
     def app(self):

--- a/horizon/pdp.py
+++ b/horizon/pdp.py
@@ -158,9 +158,9 @@ def _warn_if_operational_route_auth_disabled() -> None:
     if not sidecar_config.ENFORCE_OPERATIONAL_ROUTE_AUTH:
         logger.warning(
             "ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF: the update-trigger routes (/policy-updater/trigger, "
-            "/data-updater/trigger, /update_policy, /update_policy_data) and /kong accept UNAUTHENTICATED "
-            "requests - would-be rejections are only logged. This is the safe fleet-rollout default; set "
-            "ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on these routes."
+            "/data-updater/trigger, /update_policy, /update_policy_data) and /kong accept requests WITHOUT "
+            "a valid PDP token (missing or invalid) - would-be rejections are only logged. This is the safe "
+            "fleet-rollout default; set ENFORCE_OPERATIONAL_ROUTE_AUTH=true to enforce the PDP token on these routes."
         )
 
 

--- a/horizon/tests/conftest.py
+++ b/horizon/tests/conftest.py
@@ -22,22 +22,7 @@ import inspect
 from unittest.mock import Mock
 
 import aioresponses.core as _aioresponses_core
-import horizon.authentication as _authentication
-import pytest
 from aiohttp.client_reqrep import ClientResponse as _ClientResponse
-
-
-@pytest.fixture(autouse=True)
-def _reset_operational_warn_throttle():
-    """Give each test a clean warn-and-allow throttle window.
-
-    enforce_pdp_token_operational coalesces its "unauthenticated but allowed" warning to one line per
-    route per interval, and that state is process-global. Without this reset, a test that asserts the
-    warning could be silently suppressed by an earlier test that already logged for the same path.
-    """
-    _authentication.reset_operational_warn_throttle()
-    yield
-
 
 if "stream_writer" in inspect.signature(_ClientResponse.__init__).parameters:
 

--- a/horizon/tests/conftest.py
+++ b/horizon/tests/conftest.py
@@ -22,7 +22,21 @@ import inspect
 from unittest.mock import Mock
 
 import aioresponses.core as _aioresponses_core
+import horizon.authentication as _authentication
+import pytest
 from aiohttp.client_reqrep import ClientResponse as _ClientResponse
+
+
+@pytest.fixture(autouse=True)
+def _reset_operational_warn_throttle():
+    """Give each test a clean warn-and-allow throttle window.
+
+    enforce_pdp_token_operational coalesces its "unauthenticated but allowed" warning to one line per
+    route per interval, and that state is process-global. Without this reset, a test that asserts the
+    warning could be silently suppressed by an earlier test that already logged for the same path.
+    """
+    _authentication.reset_operational_warn_throttle()
+    yield
 
 if "stream_writer" in inspect.signature(_ClientResponse.__init__).parameters:
 

--- a/horizon/tests/conftest.py
+++ b/horizon/tests/conftest.py
@@ -22,7 +22,22 @@ import inspect
 from unittest.mock import Mock
 
 import aioresponses.core as _aioresponses_core
+import horizon.authentication as _authentication
+import pytest
 from aiohttp.client_reqrep import ClientResponse as _ClientResponse
+
+
+@pytest.fixture(autouse=True)
+def _reset_operational_warn_throttle():
+    """Give each test a clean warn-and-allow throttle window.
+
+    enforce_pdp_token_operational coalesces its "unauthenticated but allowed" warning to one line per
+    route per interval, and that state is process-global. Without this reset, a test that asserts the
+    warning could be silently suppressed by an earlier test that already logged for the same path.
+    """
+    _authentication.reset_operational_warn_throttle()
+    yield
+
 
 if "stream_writer" in inspect.signature(_ClientResponse.__init__).parameters:
 

--- a/horizon/tests/conftest.py
+++ b/horizon/tests/conftest.py
@@ -38,6 +38,7 @@ def _reset_operational_warn_throttle():
     _authentication.reset_operational_warn_throttle()
     yield
 
+
 if "stream_writer" in inspect.signature(_ClientResponse.__init__).parameters:
 
     class _StreamWriterCompatClientResponse(_ClientResponse):

--- a/horizon/tests/test_authentication.py
+++ b/horizon/tests/test_authentication.py
@@ -7,6 +7,7 @@ constant-time token comparison, the 401/503 contract of the two dependencies, an
 public-route allowlist that the route-audit test relies on.
 """
 
+import time
 from types import SimpleNamespace
 
 import horizon.authentication as auth
@@ -130,6 +131,28 @@ class TestEnforcePdpTokenOperational:
         # A caller that already sends the token is not flagged - only would-be rejections warn.
         assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
         assert not any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_coalesces_repeated_warnings(self, capture_loguru):
+        # The warn-and-allow path must not log once per request (that floods the hot /kong endpoint):
+        # a burst of would-be rejections on one route collapses to a single warning line.
+        for _ in range(50):
+            assert enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None) is None
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
+
+
+def test_operational_warn_throttle_coalesces_count():
+    # First hit for a path emits immediately (count 1); further hits within the interval are counted
+    # but suppressed; once the interval elapses the next hit emits carrying the coalesced total.
+    auth.reset_operational_warn_throttle()
+    assert auth._operational_warn_should_emit("/kong") == (True, 1)
+    for _ in range(4):
+        emit, _count = auth._operational_warn_should_emit("/kong")
+        assert emit is False
+    # Simulate the interval having elapsed without waiting on the wall clock.
+    pending, _last = auth._operational_warn_state["/kong"]
+    auth._operational_warn_state["/kong"] = (pending, time.monotonic() - (auth._OPERATIONAL_WARN_INTERVAL_SECONDS + 1))
+    assert auth._operational_warn_should_emit("/kong") == (True, 5)
 
 
 @pytest.fixture

--- a/horizon/tests/test_authentication.py
+++ b/horizon/tests/test_authentication.py
@@ -7,7 +7,6 @@ constant-time token comparison, the 401/503 contract of the two dependencies, an
 public-route allowlist that the route-audit test relies on.
 """
 
-import time
 from types import SimpleNamespace
 
 import horizon.authentication as auth
@@ -140,19 +139,62 @@ class TestEnforcePdpTokenOperational:
             assert enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None) is None
         assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
 
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_coalesces_per_route_not_globally(self, capture_loguru):
+        # The throttle is keyed per route, not globally: a burst on /kong must not swallow the first
+        # warning for a *different* route. A regression collapsing the throttle to one global key
+        # would drop the second route's warning and this assertion would see only one line.
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/policy-updater/trigger"), credentials=None)
+        warnings = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
+        assert len(warnings) == 2  # one first-hit line per distinct route; the rest coalesced
+        assert any("/kong" in record for record in warnings)
+        assert any("/policy-updater/trigger" in record for record in warnings)
 
-def test_operational_warn_throttle_coalesces_count():
-    # First hit for a path emits immediately (count 1); further hits within the interval are counted
-    # but suppressed; once the interval elapses the next hit emits carrying the coalesced total.
-    auth.reset_operational_warn_throttle()
-    assert auth._operational_warn_should_emit("/kong") == (True, 1)
-    for _ in range(4):
-        emit, _count = auth._operational_warn_should_emit("/kong")
-        assert emit is False
-    # Simulate the interval having elapsed without waiting on the wall clock.
-    pending, _last = auth._operational_warn_state["/kong"]
-    auth._operational_warn_state["/kong"] = (pending, time.monotonic() - (auth._OPERATIONAL_WARN_INTERVAL_SECONDS + 1))
-    assert auth._operational_warn_should_emit("/kong") == (True, 5)
+    @pytest.mark.usefixtures("enforce_off")
+    def test_flush_residuals_surfaces_idle_route_tail(self, capture_loguru):
+        # A route that falls idle mid-window strands the requests coalesced since its last warning;
+        # the shutdown flush surfaces that tail so "the logs went quiet" cannot hide a lagging caller.
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+        # Only the first hit has been logged; the other four are pending and unreported.
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
+        auth.flush_operational_warn_residuals()
+        flushed = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
+        assert len(flushed) == 2
+        assert "flushing 4 further request(s)" in flushed[1]
+        # Residual cleared: a second flush is a no-op.
+        auth.flush_operational_warn_residuals()
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 2
+
+
+def test_operational_warn_coalesced_count_and_window_via_public_gate(monkeypatch, capture_loguru):
+    """Count accuracy and the reported window, exercised through the public gate with a fake clock.
+
+    Drives ``enforce_pdp_token_operational`` (not the private throttle) and asserts on the emitted log
+    lines, so it pins the observable coalescing contract rather than the throttle's internal tuple
+    shape - and crosses the interval by advancing a fake ``time.monotonic`` instead of sleeping.
+    """
+    monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
+    fake_clock = {"now": 1000.0}
+    monkeypatch.setattr(auth.time, "monotonic", lambda: fake_clock["now"])
+
+    # First would-be rejection emits immediately (count 1); the next four within the window coalesce.
+    for _ in range(5):
+        enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+    # Advance past the interval so the next hit flushes the coalesced total (the four held + this one).
+    fake_clock["now"] += auth._OPERATIONAL_WARN_INTERVAL_SECONDS + 1
+    enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+
+    warnings = [record for record in capture_loguru if "ENFORCE_OPERATIONAL_ROUTE_AUTH is off" in record]
+    assert len(warnings) == 2
+    assert "allowed 1 request(s)" in warnings[0]
+    assert "allowed 5 request(s)" in warnings[1]
+    # The reported window is the real elapsed span (~61s), not the fixed 60s interval.
+    assert "in the last ~61s" in warnings[1]
 
 
 @pytest.fixture

--- a/horizon/tests/test_authentication.py
+++ b/horizon/tests/test_authentication.py
@@ -7,6 +7,8 @@ constant-time token comparison, the 401/503 contract of the two dependencies, an
 public-route allowlist that the route-audit test relies on.
 """
 
+from types import SimpleNamespace
+
 import horizon.authentication as auth
 import pytest
 from fastapi import HTTPException, status
@@ -16,8 +18,10 @@ from horizon.authentication import (
     _token_matches,
     enforce_pdp_control_key,
     enforce_pdp_token,
+    enforce_pdp_token_operational,
 )
 from horizon.config import MOCK_API_KEY, sidecar_config
+from loguru import logger
 
 VALID_TOKEN = "s3cr3t-token"
 
@@ -25,6 +29,11 @@ VALID_TOKEN = "s3cr3t-token"
 def _creds(token: str) -> HTTPAuthorizationCredentials:
     """Build what HTTPBearer hands the dependency for a well-formed ``Bearer <token>``."""
     return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _fake_request(path: str = "/policy-updater/trigger", method: str = "POST") -> SimpleNamespace:
+    """A stand-in for the Request; the compat wrapper only reads ``.method`` and ``.url.path``."""
+    return SimpleNamespace(method=method, url=SimpleNamespace(path=path))
 
 
 @pytest.mark.parametrize(
@@ -67,6 +76,68 @@ class TestEnforcePdpToken:
             enforce_pdp_token(credentials=_creds("nope"))
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
         assert exc.value.detail == "Invalid PDP token"
+
+
+class TestEnforcePdpTokenOperational:
+    """The ENFORCE_OPERATIONAL_ROUTE_AUTH wrapper: enforce when on, warn-and-allow when off (default)."""
+
+    WARN_SUBSTRING = "ENFORCE_OPERATIONAL_ROUTE_AUTH is off"
+
+    @pytest.fixture(autouse=True)
+    def _patch_key(self, monkeypatch):
+        monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
+
+    @pytest.fixture
+    def enforce_on(self, monkeypatch):
+        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
+
+    @pytest.fixture
+    def enforce_off(self, monkeypatch):
+        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_missing_credentials_is_401(self):
+        # Flag on: identical to enforce_pdp_token.
+        with pytest.raises(HTTPException) as exc:
+            enforce_pdp_token_operational(_fake_request(), credentials=None)
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc.value.detail == "Missing Authorization header"
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_wrong_token_is_401(self):
+        with pytest.raises(HTTPException) as exc:
+            enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope"))
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc.value.detail == "Invalid PDP token"
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_valid_token_passes(self):
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_missing_credentials_is_allowed_and_warns(self, capture_loguru):
+        # The rollout default: a request that would be rejected is let through, but logged.
+        assert enforce_pdp_token_operational(_fake_request(), credentials=None) is None
+        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_wrong_token_is_allowed_and_warns(self, capture_loguru):
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope")) is None
+        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_valid_token_passes_without_warning(self, capture_loguru):
+        # A caller that already sends the token is not flagged - only would-be rejections warn.
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
+        assert not any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+
+@pytest.fixture
+def capture_loguru():
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="WARNING")
+    yield records
+    logger.remove(sink_id)
 
 
 class TestEnforcePdpControlKey:

--- a/horizon/tests/test_authentication.py
+++ b/horizon/tests/test_authentication.py
@@ -7,6 +7,8 @@ constant-time token comparison, the 401/503 contract of the two dependencies, an
 public-route allowlist that the route-audit test relies on.
 """
 
+from types import SimpleNamespace
+
 import horizon.authentication as auth
 import pytest
 from fastapi import HTTPException, status
@@ -16,8 +18,10 @@ from horizon.authentication import (
     _token_matches,
     enforce_pdp_control_key,
     enforce_pdp_token,
+    enforce_pdp_token_operational,
 )
 from horizon.config import MOCK_API_KEY, sidecar_config
+from loguru import logger
 
 VALID_TOKEN = "s3cr3t-token"
 
@@ -25,6 +29,11 @@ VALID_TOKEN = "s3cr3t-token"
 def _creds(token: str) -> HTTPAuthorizationCredentials:
     """Build what HTTPBearer hands the dependency for a well-formed ``Bearer <token>``."""
     return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def _fake_request(path: str = "/policy-updater/trigger", method: str = "POST") -> SimpleNamespace:
+    """A stand-in for the Request; the compat wrapper only reads ``.method`` and ``.url.path``."""
+    return SimpleNamespace(method=method, url=SimpleNamespace(path=path))
 
 
 @pytest.mark.parametrize(
@@ -67,6 +76,133 @@ class TestEnforcePdpToken:
             enforce_pdp_token(credentials=_creds("nope"))
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
         assert exc.value.detail == "Invalid PDP token"
+
+
+class TestEnforcePdpTokenOperational:
+    """The ENFORCE_OPERATIONAL_ROUTE_AUTH wrapper: enforce when on, warn-and-allow when off (default)."""
+
+    WARN_SUBSTRING = "ENFORCE_OPERATIONAL_ROUTE_AUTH is off"
+
+    @pytest.fixture(autouse=True)
+    def _patch_key(self, monkeypatch):
+        monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
+
+    @pytest.fixture
+    def enforce_on(self, monkeypatch):
+        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
+
+    @pytest.fixture
+    def enforce_off(self, monkeypatch):
+        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_missing_credentials_is_401(self):
+        # Flag on: identical to enforce_pdp_token.
+        with pytest.raises(HTTPException) as exc:
+            enforce_pdp_token_operational(_fake_request(), credentials=None)
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc.value.detail == "Missing Authorization header"
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_wrong_token_is_401(self):
+        with pytest.raises(HTTPException) as exc:
+            enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope"))
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert exc.value.detail == "Invalid PDP token"
+
+    @pytest.mark.usefixtures("enforce_on")
+    def test_enforce_on_valid_token_passes(self):
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_missing_credentials_is_allowed_and_warns(self, capture_loguru):
+        # The rollout default: a request that would be rejected is let through, but logged.
+        assert enforce_pdp_token_operational(_fake_request(), credentials=None) is None
+        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_wrong_token_is_allowed_and_warns(self, capture_loguru):
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope")) is None
+        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_valid_token_passes_without_warning(self, capture_loguru):
+        # A caller that already sends the token is not flagged - only would-be rejections warn.
+        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
+        assert not any(self.WARN_SUBSTRING in record for record in capture_loguru)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_coalesces_repeated_warnings(self, capture_loguru):
+        # The warn-and-allow path must not log once per request (that floods the hot /kong endpoint):
+        # a burst of would-be rejections on one route collapses to a single warning line.
+        for _ in range(50):
+            assert enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None) is None
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_enforce_off_coalesces_per_route_not_globally(self, capture_loguru):
+        # The throttle is keyed per route, not globally: a burst on /kong must not swallow the first
+        # warning for a *different* route. A regression collapsing the throttle to one global key
+        # would drop the second route's warning and this assertion would see only one line.
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/policy-updater/trigger"), credentials=None)
+        warnings = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
+        assert len(warnings) == 2  # one first-hit line per distinct route; the rest coalesced
+        assert any("/kong" in record for record in warnings)
+        assert any("/policy-updater/trigger" in record for record in warnings)
+
+    @pytest.mark.usefixtures("enforce_off")
+    def test_flush_residuals_surfaces_idle_route_tail(self, capture_loguru):
+        # A route that falls idle mid-window strands the requests coalesced since its last warning;
+        # the shutdown flush surfaces that tail so "the logs went quiet" cannot hide a lagging caller.
+        for _ in range(5):
+            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+        # Only the first hit has been logged; the other four are pending and unreported.
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
+        auth.flush_operational_warn_residuals()
+        flushed = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
+        assert len(flushed) == 2
+        assert "flushing 4 further request(s)" in flushed[1]
+        # Residual cleared: a second flush is a no-op.
+        auth.flush_operational_warn_residuals()
+        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 2
+
+
+def test_operational_warn_coalesced_count_and_window_via_public_gate(monkeypatch, capture_loguru):
+    """Count accuracy and the reported window, exercised through the public gate with a fake clock.
+
+    Drives ``enforce_pdp_token_operational`` (not the private throttle) and asserts on the emitted log
+    lines, so it pins the observable coalescing contract rather than the throttle's internal tuple
+    shape - and crosses the interval by advancing a fake ``time.monotonic`` instead of sleeping.
+    """
+    monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
+    fake_clock = {"now": 1000.0}
+    monkeypatch.setattr(auth.time, "monotonic", lambda: fake_clock["now"])
+
+    # First would-be rejection emits immediately (count 1); the next four within the window coalesce.
+    for _ in range(5):
+        enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+    # Advance past the interval so the next hit flushes the coalesced total (the four held + this one).
+    fake_clock["now"] += auth._OPERATIONAL_WARN_INTERVAL_SECONDS + 1
+    enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
+
+    warnings = [record for record in capture_loguru if "ENFORCE_OPERATIONAL_ROUTE_AUTH is off" in record]
+    assert len(warnings) == 2
+    assert "allowed 1 request(s)" in warnings[0]
+    assert "allowed 5 request(s)" in warnings[1]
+    # The reported window is the real elapsed span (~61s), not the fixed 60s interval.
+    assert "in the last ~61s" in warnings[1]
+
+
+@pytest.fixture
+def capture_loguru():
+    records: list[str] = []
+    sink_id = logger.add(lambda message: records.append(str(message)), level="WARNING")
+    yield records
+    logger.remove(sink_id)
 
 
 class TestEnforcePdpControlKey:

--- a/horizon/tests/test_authentication.py
+++ b/horizon/tests/test_authentication.py
@@ -7,8 +7,6 @@ constant-time token comparison, the 401/503 contract of the two dependencies, an
 public-route allowlist that the route-audit test relies on.
 """
 
-from types import SimpleNamespace
-
 import horizon.authentication as auth
 import pytest
 from fastapi import HTTPException, status
@@ -18,10 +16,8 @@ from horizon.authentication import (
     _token_matches,
     enforce_pdp_control_key,
     enforce_pdp_token,
-    enforce_pdp_token_operational,
 )
 from horizon.config import MOCK_API_KEY, sidecar_config
-from loguru import logger
 
 VALID_TOKEN = "s3cr3t-token"
 
@@ -29,11 +25,6 @@ VALID_TOKEN = "s3cr3t-token"
 def _creds(token: str) -> HTTPAuthorizationCredentials:
     """Build what HTTPBearer hands the dependency for a well-formed ``Bearer <token>``."""
     return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-
-
-def _fake_request(path: str = "/policy-updater/trigger", method: str = "POST") -> SimpleNamespace:
-    """A stand-in for the Request; the compat wrapper only reads ``.method`` and ``.url.path``."""
-    return SimpleNamespace(method=method, url=SimpleNamespace(path=path))
 
 
 @pytest.mark.parametrize(
@@ -76,133 +67,6 @@ class TestEnforcePdpToken:
             enforce_pdp_token(credentials=_creds("nope"))
         assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
         assert exc.value.detail == "Invalid PDP token"
-
-
-class TestEnforcePdpTokenOperational:
-    """The ENFORCE_OPERATIONAL_ROUTE_AUTH wrapper: enforce when on, warn-and-allow when off (default)."""
-
-    WARN_SUBSTRING = "ENFORCE_OPERATIONAL_ROUTE_AUTH is off"
-
-    @pytest.fixture(autouse=True)
-    def _patch_key(self, monkeypatch):
-        monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
-
-    @pytest.fixture
-    def enforce_on(self, monkeypatch):
-        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
-
-    @pytest.fixture
-    def enforce_off(self, monkeypatch):
-        monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
-
-    @pytest.mark.usefixtures("enforce_on")
-    def test_enforce_on_missing_credentials_is_401(self):
-        # Flag on: identical to enforce_pdp_token.
-        with pytest.raises(HTTPException) as exc:
-            enforce_pdp_token_operational(_fake_request(), credentials=None)
-        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == "Missing Authorization header"
-
-    @pytest.mark.usefixtures("enforce_on")
-    def test_enforce_on_wrong_token_is_401(self):
-        with pytest.raises(HTTPException) as exc:
-            enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope"))
-        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
-        assert exc.value.detail == "Invalid PDP token"
-
-    @pytest.mark.usefixtures("enforce_on")
-    def test_enforce_on_valid_token_passes(self):
-        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_enforce_off_missing_credentials_is_allowed_and_warns(self, capture_loguru):
-        # The rollout default: a request that would be rejected is let through, but logged.
-        assert enforce_pdp_token_operational(_fake_request(), credentials=None) is None
-        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_enforce_off_wrong_token_is_allowed_and_warns(self, capture_loguru):
-        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds("nope")) is None
-        assert any(self.WARN_SUBSTRING in record for record in capture_loguru)
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_enforce_off_valid_token_passes_without_warning(self, capture_loguru):
-        # A caller that already sends the token is not flagged - only would-be rejections warn.
-        assert enforce_pdp_token_operational(_fake_request(), credentials=_creds(VALID_TOKEN)) is None
-        assert not any(self.WARN_SUBSTRING in record for record in capture_loguru)
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_enforce_off_coalesces_repeated_warnings(self, capture_loguru):
-        # The warn-and-allow path must not log once per request (that floods the hot /kong endpoint):
-        # a burst of would-be rejections on one route collapses to a single warning line.
-        for _ in range(50):
-            assert enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None) is None
-        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_enforce_off_coalesces_per_route_not_globally(self, capture_loguru):
-        # The throttle is keyed per route, not globally: a burst on /kong must not swallow the first
-        # warning for a *different* route. A regression collapsing the throttle to one global key
-        # would drop the second route's warning and this assertion would see only one line.
-        for _ in range(5):
-            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
-        for _ in range(5):
-            enforce_pdp_token_operational(_fake_request(path="/policy-updater/trigger"), credentials=None)
-        warnings = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
-        assert len(warnings) == 2  # one first-hit line per distinct route; the rest coalesced
-        assert any("/kong" in record for record in warnings)
-        assert any("/policy-updater/trigger" in record for record in warnings)
-
-    @pytest.mark.usefixtures("enforce_off")
-    def test_flush_residuals_surfaces_idle_route_tail(self, capture_loguru):
-        # A route that falls idle mid-window strands the requests coalesced since its last warning;
-        # the shutdown flush surfaces that tail so "the logs went quiet" cannot hide a lagging caller.
-        for _ in range(5):
-            enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
-        # Only the first hit has been logged; the other four are pending and unreported.
-        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 1
-        auth.flush_operational_warn_residuals()
-        flushed = [record for record in capture_loguru if self.WARN_SUBSTRING in record]
-        assert len(flushed) == 2
-        assert "flushing 4 further request(s)" in flushed[1]
-        # Residual cleared: a second flush is a no-op.
-        auth.flush_operational_warn_residuals()
-        assert sum(self.WARN_SUBSTRING in record for record in capture_loguru) == 2
-
-
-def test_operational_warn_coalesced_count_and_window_via_public_gate(monkeypatch, capture_loguru):
-    """Count accuracy and the reported window, exercised through the public gate with a fake clock.
-
-    Drives ``enforce_pdp_token_operational`` (not the private throttle) and asserts on the emitted log
-    lines, so it pins the observable coalescing contract rather than the throttle's internal tuple
-    shape - and crosses the interval by advancing a fake ``time.monotonic`` instead of sleeping.
-    """
-    monkeypatch.setattr(auth, "get_env_api_key", lambda: VALID_TOKEN)
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
-    fake_clock = {"now": 1000.0}
-    monkeypatch.setattr(auth.time, "monotonic", lambda: fake_clock["now"])
-
-    # First would-be rejection emits immediately (count 1); the next four within the window coalesce.
-    for _ in range(5):
-        enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
-    # Advance past the interval so the next hit flushes the coalesced total (the four held + this one).
-    fake_clock["now"] += auth._OPERATIONAL_WARN_INTERVAL_SECONDS + 1
-    enforce_pdp_token_operational(_fake_request(path="/kong"), credentials=None)
-
-    warnings = [record for record in capture_loguru if "ENFORCE_OPERATIONAL_ROUTE_AUTH is off" in record]
-    assert len(warnings) == 2
-    assert "allowed 1 request(s)" in warnings[0]
-    assert "allowed 5 request(s)" in warnings[1]
-    # The reported window is the real elapsed span (~61s), not the fixed 60s interval.
-    assert "in the last ~61s" in warnings[1]
-
-
-@pytest.fixture
-def capture_loguru():
-    records: list[str] = []
-    sink_id = logger.add(lambda message: records.append(str(message)), level="WARNING")
-    yield records
-    logger.remove(sink_id)
 
 
 class TestEnforcePdpControlKey:

--- a/horizon/tests/test_enforcer_api.py
+++ b/horizon/tests/test_enforcer_api.py
@@ -81,18 +81,7 @@ KONG_QUERY = {
 }
 
 
-@pytest.fixture
-def enforce_operational_auth(monkeypatch):
-    """Enable ENFORCE_OPERATIONAL_ROUTE_AUTH so the conditionally-gated route (/kong) also rejects.
-
-    The 8 other endpoints in the sweep carry the plain enforce_pdp_token gate and reject regardless;
-    /kong defaults to permissive (rollout default), so the sweep turns enforcement on to cover it too.
-    """
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
-
-
 @pytest.mark.parametrize("endpoint", PROTECTED_ENFORCER_ENDPOINTS)
-@pytest.mark.usefixtures("enforce_operational_auth")
 def test_enforcer_endpoint_missing_token_returns_401(endpoint):
     client = TestClient(sidecar._app)
     response = client.post(endpoint, json={})
@@ -101,7 +90,6 @@ def test_enforcer_endpoint_missing_token_returns_401(endpoint):
 
 
 @pytest.mark.parametrize("endpoint", PROTECTED_ENFORCER_ENDPOINTS)
-@pytest.mark.usefixtures("enforce_operational_auth")
 def test_enforcer_endpoint_invalid_token_returns_401(endpoint):
     client = TestClient(sidecar._app)
     response = client.post(endpoint, headers={"authorization": "Bearer wrong_token"}, json={})
@@ -127,22 +115,11 @@ def test_kong_endpoint_valid_token_integration_disabled_returns_503():
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
 
-def test_kong_endpoint_permissive_default_bypasses_auth():
-    # Rollout default (ENFORCE_OPERATIONAL_ROUTE_AUTH off): a tokenless /kong is no longer 401 - the
-    # gate lets it through to the handler, which then 503s because KONG_INTEGRATION is off. The 503
-    # (not 401) is the proof that the auth gate allowed it through.
-    client = TestClient(sidecar._app)
-    response = client.post("/kong", json=KONG_QUERY)
-    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-
-
 def test_kong_endpoint_enabled_integration_allowed_flow(tmp_path, monkeypatch):
     routes_file = tmp_path / "kong_routes.json"
     routes_file.write_text('[["^/resource1/.*$", "resource1"]]')
     monkeypatch.setattr("horizon.enforcer.api.KONG_ROUTES_TABLE_FILE", str(routes_file))
     monkeypatch.setattr(sidecar_config, "KONG_INTEGRATION", True)
-    # /kong defaults to permissive; enable enforcement so the tokenless call below is a clean 401.
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
 
     class FakeStateHandler:
         async def seen_sdk(self, _sdk: str) -> None:

--- a/horizon/tests/test_enforcer_api.py
+++ b/horizon/tests/test_enforcer_api.py
@@ -81,7 +81,18 @@ KONG_QUERY = {
 }
 
 
+@pytest.fixture
+def enforce_operational_auth(monkeypatch):
+    """Enable ENFORCE_OPERATIONAL_ROUTE_AUTH so the conditionally-gated route (/kong) also rejects.
+
+    The 8 other endpoints in the sweep carry the plain enforce_pdp_token gate and reject regardless;
+    /kong defaults to permissive (rollout default), so the sweep turns enforcement on to cover it too.
+    """
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
+
+
 @pytest.mark.parametrize("endpoint", PROTECTED_ENFORCER_ENDPOINTS)
+@pytest.mark.usefixtures("enforce_operational_auth")
 def test_enforcer_endpoint_missing_token_returns_401(endpoint):
     client = TestClient(sidecar._app)
     response = client.post(endpoint, json={})
@@ -90,6 +101,7 @@ def test_enforcer_endpoint_missing_token_returns_401(endpoint):
 
 
 @pytest.mark.parametrize("endpoint", PROTECTED_ENFORCER_ENDPOINTS)
+@pytest.mark.usefixtures("enforce_operational_auth")
 def test_enforcer_endpoint_invalid_token_returns_401(endpoint):
     client = TestClient(sidecar._app)
     response = client.post(endpoint, headers={"authorization": "Bearer wrong_token"}, json={})
@@ -115,11 +127,22 @@ def test_kong_endpoint_valid_token_integration_disabled_returns_503():
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
 
+def test_kong_endpoint_permissive_default_bypasses_auth():
+    # Rollout default (ENFORCE_OPERATIONAL_ROUTE_AUTH off): a tokenless /kong is no longer 401 - the
+    # gate lets it through to the handler, which then 503s because KONG_INTEGRATION is off. The 503
+    # (not 401) is the proof that the auth gate allowed it through.
+    client = TestClient(sidecar._app)
+    response = client.post("/kong", json=KONG_QUERY)
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
 def test_kong_endpoint_enabled_integration_allowed_flow(tmp_path, monkeypatch):
     routes_file = tmp_path / "kong_routes.json"
     routes_file.write_text('[["^/resource1/.*$", "resource1"]]')
     monkeypatch.setattr("horizon.enforcer.api.KONG_ROUTES_TABLE_FILE", str(routes_file))
     monkeypatch.setattr(sidecar_config, "KONG_INTEGRATION", True)
+    # /kong defaults to permissive; enable enforcement so the tokenless call below is a clean 401.
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
 
     class FakeStateHandler:
         async def seen_sdk(self, _sdk: str) -> None:

--- a/horizon/tests/test_legacy_update_routes.py
+++ b/horizon/tests/test_legacy_update_routes.py
@@ -35,6 +35,9 @@ def test_update_policy_triggers_updater(pdp: MockPermitPDP, auth: dict[str, str]
 
 
 def test_update_policy_rejects_unauthenticated(pdp: MockPermitPDP, monkeypatch):
+    # Rejection on these routes is now opt-in (ENFORCE_OPERATIONAL_ROUTE_AUTH defaults off for a
+    # safe fleet rollout); enable enforcement to assert the reject behaviour.
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
     trigger = AsyncMock()
     monkeypatch.setattr(pdp._opal.policy_updater, "trigger_update_policy", trigger)
     client = TestClient(pdp._app)
@@ -74,6 +77,8 @@ def test_update_policy_data_returns_503_when_updater_disabled(pdp: MockPermitPDP
 
 
 def test_update_policy_data_rejects_unauthenticated(pdp: MockPermitPDP, monkeypatch):
+    # Rejection is opt-in now (see test_update_policy_rejects_unauthenticated); enable enforcement.
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
     get_base = AsyncMock()
     monkeypatch.setattr(pdp._opal.data_updater, "get_base_policy_data", get_base)
     client = TestClient(pdp._app)

--- a/horizon/tests/test_legacy_update_routes.py
+++ b/horizon/tests/test_legacy_update_routes.py
@@ -35,9 +35,6 @@ def test_update_policy_triggers_updater(pdp: MockPermitPDP, auth: dict[str, str]
 
 
 def test_update_policy_rejects_unauthenticated(pdp: MockPermitPDP, monkeypatch):
-    # Rejection on these routes is now opt-in (ENFORCE_OPERATIONAL_ROUTE_AUTH defaults off for a
-    # safe fleet rollout); enable enforcement to assert the reject behaviour.
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
     trigger = AsyncMock()
     monkeypatch.setattr(pdp._opal.policy_updater, "trigger_update_policy", trigger)
     client = TestClient(pdp._app)
@@ -77,8 +74,6 @@ def test_update_policy_data_returns_503_when_updater_disabled(pdp: MockPermitPDP
 
 
 def test_update_policy_data_rejects_unauthenticated(pdp: MockPermitPDP, monkeypatch):
-    # Rejection is opt-in now (see test_update_policy_rejects_unauthenticated); enable enforcement.
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
     get_base = AsyncMock()
     monkeypatch.setattr(pdp._opal.data_updater, "get_base_policy_data", get_base)
     client = TestClient(pdp._app)

--- a/horizon/tests/test_opal_trigger_auth.py
+++ b/horizon/tests/test_opal_trigger_auth.py
@@ -16,13 +16,16 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from horizon.config import sidecar_config
 from horizon.enforcer.api import stats_manager
-from horizon.pdp import PermitPDP, _warn_if_opal_verifier_disabled
+from horizon.pdp import PermitPDP, _warn_if_opal_verifier_disabled, _warn_if_operational_route_auth_disabled
 from loguru import logger
 from opal_client.client import OpalClient
 from starlette import status
 
 VALID_TOKEN = "mock_api_key"
 TRIGGER_ROUTES = ["/policy-updater/trigger", "/data-updater/trigger"]
+# The legacy SDK aliases of the two trigger routes; gated with the same operational wrapper.
+LEGACY_TRIGGER_ROUTES = ["/update_policy", "/update_policy_data"]
+OPERATIONAL_UPDATE_ROUTES = TRIGGER_ROUTES + LEGACY_TRIGGER_ROUTES
 
 
 class MockPermitPDP(PermitPDP):
@@ -49,7 +52,18 @@ def _auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+@pytest.fixture
+def enforce_on(monkeypatch):
+    """Turn ENFORCE_OPERATIONAL_ROUTE_AUTH on (read per-request by the gate) so these routes reject."""
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
+
+
+# The trigger-route enforcement tests below assert the reject behaviour, which is now opt-in
+# (ENFORCE_OPERATIONAL_ROUTE_AUTH defaults to off for a safe fleet rollout), so they enable it.
+
+
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
+@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_without_token_is_401(client: TestClient, path: str):
     # The actual vulnerability: OPAL-mounted trigger routes were callable unauthenticated.
     resp = client.post(path)
@@ -59,12 +73,14 @@ def test_trigger_route_without_token_is_401(client: TestClient, path: str):
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
 def test_trigger_route_with_valid_token_is_not_blocked(client: TestClient, path: str):
-    # The dependency passes; the handler may 500 offline, but it must not be a 401.
+    # The dependency passes; the handler may 500 offline, but it must not be a 401. True in both
+    # enforcement modes, so left flag-agnostic.
     resp = client.post(path, headers=_auth(VALID_TOKEN))
     assert resp.status_code != status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
+@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_with_wrong_token_is_401(client: TestClient, path: str):
     resp = client.post(path, headers=_auth("wrong-token"))
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
@@ -73,6 +89,7 @@ def test_trigger_route_with_wrong_token_is_401(client: TestClient, path: str):
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
 @pytest.mark.parametrize("value", ["garbage", "Bearer", "Bearer ", "Bearer a b c"])
+@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_malformed_header_is_401_not_500(client: TestClient, path: str, value: str):
     # Regression for the unguarded split(" ") -> ValueError -> 500 footgun.
     resp = client.post(path, headers={"Authorization": value})
@@ -106,6 +123,44 @@ def test_exit_without_header_is_503_when_control_key_unset(client: TestClient):
     # Control key is unset in tests, so enforce_pdp_control_key short-circuits to 503
     # (before any header check) - now reachable because the header param defaults to None.
     assert client.post("/_exit").status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
+@pytest.mark.usefixtures("enforce_on")
+def test_update_route_without_token_is_401_when_enforced(client: TestClient, path: str):
+    # With enforcement on, the update-trigger + legacy routes reject a tokenless call.
+    assert client.post(path).status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
+def test_update_route_without_token_is_allowed_by_default(client: TestClient, path: str):
+    # Rollout default (enforcement off, no flag set here): a tokenless call is not blocked. It may
+    # 500 on real offline I/O once it reaches the handler, but it must not be the auth 401 - which
+    # proves the gate allowed it through.
+    assert client.post(path).status_code != status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
+def test_update_route_wrong_token_is_allowed_by_default(client: TestClient, path: str):
+    assert client.post(path, headers=_auth("wrong-token")).status_code != status.HTTP_401_UNAUTHORIZED
+
+
+def test_default_permissive_logs_would_be_rejection(client: TestClient, capture_loguru):
+    # The escape hatch is observable: each would-be rejection is logged so lagging callers surface.
+    client.post("/policy-updater/trigger")
+    assert any("ENFORCE_OPERATIONAL_ROUTE_AUTH is off" in record for record in capture_loguru)
+
+
+def test_warn_if_operational_route_auth_disabled_fires_when_off(monkeypatch, capture_loguru):
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
+    _warn_if_operational_route_auth_disabled()
+    assert any("ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF" in record for record in capture_loguru)
+
+
+def test_warn_if_operational_route_auth_disabled_silent_when_on(monkeypatch, capture_loguru):
+    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
+    _warn_if_operational_route_auth_disabled()
+    assert not any("ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF" in record for record in capture_loguru)
 
 
 def test_warn_if_opal_verifier_disabled_fires(capture_loguru):

--- a/horizon/tests/test_opal_trigger_auth.py
+++ b/horizon/tests/test_opal_trigger_auth.py
@@ -16,16 +16,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from horizon.config import sidecar_config
 from horizon.enforcer.api import stats_manager
-from horizon.pdp import PermitPDP, _warn_if_opal_verifier_disabled, _warn_if_operational_route_auth_disabled
+from horizon.pdp import PermitPDP, _warn_if_opal_verifier_disabled
 from loguru import logger
 from opal_client.client import OpalClient
 from starlette import status
 
 VALID_TOKEN = "mock_api_key"
 TRIGGER_ROUTES = ["/policy-updater/trigger", "/data-updater/trigger"]
-# The legacy SDK aliases of the two trigger routes; gated with the same operational wrapper.
-LEGACY_TRIGGER_ROUTES = ["/update_policy", "/update_policy_data"]
-OPERATIONAL_UPDATE_ROUTES = TRIGGER_ROUTES + LEGACY_TRIGGER_ROUTES
 
 
 class MockPermitPDP(PermitPDP):
@@ -52,18 +49,7 @@ def _auth(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-@pytest.fixture
-def enforce_on(monkeypatch):
-    """Turn ENFORCE_OPERATIONAL_ROUTE_AUTH on (read per-request by the gate) so these routes reject."""
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
-
-
-# The trigger-route enforcement tests below assert the reject behaviour, which is now opt-in
-# (ENFORCE_OPERATIONAL_ROUTE_AUTH defaults to off for a safe fleet rollout), so they enable it.
-
-
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
-@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_without_token_is_401(client: TestClient, path: str):
     # The actual vulnerability: OPAL-mounted trigger routes were callable unauthenticated.
     resp = client.post(path)
@@ -73,14 +59,12 @@ def test_trigger_route_without_token_is_401(client: TestClient, path: str):
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
 def test_trigger_route_with_valid_token_is_not_blocked(client: TestClient, path: str):
-    # The dependency passes; the handler may 500 offline, but it must not be a 401. True in both
-    # enforcement modes, so left flag-agnostic.
+    # The dependency passes; the handler may 500 offline, but it must not be a 401.
     resp = client.post(path, headers=_auth(VALID_TOKEN))
     assert resp.status_code != status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
-@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_with_wrong_token_is_401(client: TestClient, path: str):
     resp = client.post(path, headers=_auth("wrong-token"))
     assert resp.status_code == status.HTTP_401_UNAUTHORIZED
@@ -89,7 +73,6 @@ def test_trigger_route_with_wrong_token_is_401(client: TestClient, path: str):
 
 @pytest.mark.parametrize("path", TRIGGER_ROUTES)
 @pytest.mark.parametrize("value", ["garbage", "Bearer", "Bearer ", "Bearer a b c"])
-@pytest.mark.usefixtures("enforce_on")
 def test_trigger_route_malformed_header_is_401_not_500(client: TestClient, path: str, value: str):
     # Regression for the unguarded split(" ") -> ValueError -> 500 footgun.
     resp = client.post(path, headers={"Authorization": value})
@@ -123,44 +106,6 @@ def test_exit_without_header_is_503_when_control_key_unset(client: TestClient):
     # Control key is unset in tests, so enforce_pdp_control_key short-circuits to 503
     # (before any header check) - now reachable because the header param defaults to None.
     assert client.post("/_exit").status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-
-
-@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
-@pytest.mark.usefixtures("enforce_on")
-def test_update_route_without_token_is_401_when_enforced(client: TestClient, path: str):
-    # With enforcement on, the update-trigger + legacy routes reject a tokenless call.
-    assert client.post(path).status_code == status.HTTP_401_UNAUTHORIZED
-
-
-@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
-def test_update_route_without_token_is_allowed_by_default(client: TestClient, path: str):
-    # Rollout default (enforcement off, no flag set here): a tokenless call is not blocked. It may
-    # 500 on real offline I/O once it reaches the handler, but it must not be the auth 401 - which
-    # proves the gate allowed it through.
-    assert client.post(path).status_code != status.HTTP_401_UNAUTHORIZED
-
-
-@pytest.mark.parametrize("path", OPERATIONAL_UPDATE_ROUTES)
-def test_update_route_wrong_token_is_allowed_by_default(client: TestClient, path: str):
-    assert client.post(path, headers=_auth("wrong-token")).status_code != status.HTTP_401_UNAUTHORIZED
-
-
-def test_default_permissive_logs_would_be_rejection(client: TestClient, capture_loguru):
-    # The escape hatch is observable: each would-be rejection is logged so lagging callers surface.
-    client.post("/policy-updater/trigger")
-    assert any("ENFORCE_OPERATIONAL_ROUTE_AUTH is off" in record for record in capture_loguru)
-
-
-def test_warn_if_operational_route_auth_disabled_fires_when_off(monkeypatch, capture_loguru):
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", False)
-    _warn_if_operational_route_auth_disabled()
-    assert any("ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF" in record for record in capture_loguru)
-
-
-def test_warn_if_operational_route_auth_disabled_silent_when_on(monkeypatch, capture_loguru):
-    monkeypatch.setattr(sidecar_config, "ENFORCE_OPERATIONAL_ROUTE_AUTH", True)
-    _warn_if_operational_route_auth_disabled()
-    assert not any("ENFORCE_OPERATIONAL_ROUTE_AUTH is OFF" in record for record in capture_loguru)
 
 
 def test_warn_if_opal_verifier_disabled_fires(capture_loguru):

--- a/horizon/tests/test_route_auth_audit.py
+++ b/horizon/tests/test_route_auth_audit.py
@@ -35,6 +35,10 @@ from starlette.routing import Route
 AUTH_GATE_CALLABLES: frozenset[str] = frozenset(
     {
         "enforce_pdp_token",
+        # ENFORCE_OPERATIONAL_ROUTE_AUTH rollout wrapper on the update-trigger and /kong routes. This
+        # audit is structural: it asserts a gate is attached, not that the gate rejects at runtime
+        # (that gate warns-and-allows while enforcement is off, the rollout default).
+        "enforce_pdp_token_operational",
         "enforce_pdp_control_key",
         "JWTAuthenticator",
         "require_listener_token",
@@ -102,10 +106,15 @@ def test_no_route_is_unprotected():
 
 @pytest.mark.parametrize("path", sorted(OPAL_TRIGGER_ROUTE_PATHS))
 def test_opal_trigger_route_is_pdp_gated(path: str):
-    """Regression guard for the actual fix: the OPAL-mounted trigger routes require the PDP token."""
+    """Regression guard for the actual fix: the OPAL-mounted trigger routes carry the PDP-token gate.
+
+    They are gated with the operational wrapper (enforce_pdp_token_operational) so
+    ENFORCE_OPERATIONAL_ROUTE_AUTH governs them during a rollout; with the flag on the wrapper enforces
+    the token identically to enforce_pdp_token. This asserts the gate is attached, not its runtime mode.
+    """
     by_path = {route.path: route for route in _sidecar._app.routes if isinstance(route, APIRoute)}
     assert path in by_path, f"{path} is no longer mounted (OPAL rename?) - _gate_opal_trigger_routes must be updated"
-    assert "enforce_pdp_token" in _route_auth_gates(by_path[path])
+    assert "enforce_pdp_token_operational" in _route_auth_gates(by_path[path])
 
 
 def test_audit_detects_a_bare_ungated_route():

--- a/horizon/tests/test_route_auth_audit.py
+++ b/horizon/tests/test_route_auth_audit.py
@@ -35,10 +35,6 @@ from starlette.routing import Route
 AUTH_GATE_CALLABLES: frozenset[str] = frozenset(
     {
         "enforce_pdp_token",
-        # ENFORCE_OPERATIONAL_ROUTE_AUTH rollout wrapper on the update-trigger and /kong routes. This
-        # audit is structural: it asserts a gate is attached, not that the gate rejects at runtime
-        # (that gate warns-and-allows while enforcement is off, the rollout default).
-        "enforce_pdp_token_operational",
         "enforce_pdp_control_key",
         "JWTAuthenticator",
         "require_listener_token",
@@ -106,15 +102,10 @@ def test_no_route_is_unprotected():
 
 @pytest.mark.parametrize("path", sorted(OPAL_TRIGGER_ROUTE_PATHS))
 def test_opal_trigger_route_is_pdp_gated(path: str):
-    """Regression guard for the actual fix: the OPAL-mounted trigger routes carry the PDP-token gate.
-
-    They are gated with the operational wrapper (enforce_pdp_token_operational) so
-    ENFORCE_OPERATIONAL_ROUTE_AUTH governs them during a rollout; with the flag on the wrapper enforces
-    the token identically to enforce_pdp_token. This asserts the gate is attached, not its runtime mode.
-    """
+    """Regression guard for the actual fix: the OPAL-mounted trigger routes require the PDP token."""
     by_path = {route.path: route for route in _sidecar._app.routes if isinstance(route, APIRoute)}
     assert path in by_path, f"{path} is no longer mounted (OPAL rename?) - _gate_opal_trigger_routes must be updated"
-    assert "enforce_pdp_token_operational" in _route_auth_gates(by_path[path])
+    assert "enforce_pdp_token" in _route_auth_gates(by_path[path])
 
 
 def test_audit_detects_a_bare_ungated_route():


### PR DESCRIPTION
## Summary

The auth-hardening PRs (#317/#320/#321) made five operational routes — the update-trigger routes (`/policy-updater/trigger`, `/data-updater/trigger`, `/update_policy`, `/update_policy_data`) and the `/kong` decision endpoint — **unconditionally** require the PDP token. That's correct as an end state, but there's no way to relax it during a coordinated fleet upgrade, and some callers (notably the Kong OPA plugin and older SDK automations) may not send the token yet. Turning it on fleet-wide today would 401 live traffic with no warning.

This PR adds one flag, `ENFORCE_OPERATIONAL_ROUTE_AUTH`, that gates those five routes. It **defaults to FALSE** for a safe rollout: the routes accept unauthenticated requests and only **log** the ones that would have been rejected, so lagging callers keep working while the logs surface exactly who they are. Once the logs go quiet, flip the flag to true per-fleet and enforcement kicks in. Every other PDP route stays strictly enforced regardless of this flag.

## How the flag behaves per request

| Flag | Valid token | Missing / wrong token |
|------|-------------|-----------------------|
| **OFF** (default, rollout phase) | passes | **allowed through**, logs a "would-be rejection" warning |
| **ON** (steady state) | passes | 401, identical to `enforce_pdp_token` |

## Why `/kong` needed a router split (and the other four routes didn't)

This is the one non-obvious part of the diff, so it's worth spelling out.

A gate (auth dependency) can be attached at two levels:

- **Route level** — attached to one individual endpoint.
- **Router level** — attached to a whole group of endpoints; every route in the group inherits it.

The four update-trigger routes already carried their gate at the **route level** (the legacy routes via their `@app.post(..., dependencies=[...])` decorator; the OPAL trigger routes via per-route injection in `_gate_opal_trigger_routes`). Swapping their strict gate for the new conditional one is a one-line change in place.

`/kong` was different. Its gate came from the **enforcer group**: `include_router(enforcer_router, dependencies=[Depends(enforce_pdp_token)])` puts the strict gate on every enforcer route at once. In FastAPI a route **can't opt out of a gate inherited from its group** — you can add a gate to a single route but not remove the group-level one. So `/kong` couldn't be made conditional while it lived in that group; the strict gate would always fire first and 401 the request before the conditional gate could be lenient.

The fix is to pull `/kong` onto its own `kong_router` so it can be mounted under the conditional gate while the rest of the enforcer router keeps the strict gate. It's a **split, not a move** — `/kong`'s handler closes over `kong_routes_table` and the nested `_is_allowed` helper, so relocating it entirely would be a much larger refactor; a router split in the same closure avoids that.

## What changed, by file

- **`horizon/config.py`** — new `ENFORCE_OPERATIONAL_ROUTE_AUTH` bool (default False), `PDP_`-prefixed env var, also overridable from the cloud control plane.
- **`horizon/authentication.py`** — new `enforce_pdp_token_operational` gate. Reads the flag **per request** (never captured at import, so a control-plane override takes effect immediately). Flag on → delegates to `enforce_pdp_token`. Flag off → downgrades a rejection to warn-and-allow. Kept as a distinct named callable so the fail-closed route audit still recognises it as a gate.
- **`horizon/enforcer/api.py`** — `/kong` moved onto its own `kong_router`; `init_enforcer_api_router` now returns `(router, kong_router)`.
- **`horizon/pdp.py`** — mounts `kong_router` under `enforce_pdp_token_operational`; the update-trigger routes now use the same operational wrapper; adds a startup warning (`_warn_if_operational_route_auth_disabled`) so a fleet in permissive mode stays visible.
- **Tests** — enforce-by-default tests from #317/#320/#321 now opt into enforcement; new tests assert the permissive default and the log throttling. 144 pass, ruff clean.

## Log throttling (specific to `/kong`)

`/kong` is a high-QPS endpoint, so one warning per unauthenticated request would flood the synchronous stdout sink and add a blocking write to the request hot path. The warn-and-allow path therefore coalesces to **one line per route per ~60s**, carrying a count of how many would-be rejections it allowed. That count is also the rollout signal — watch it fall to zero on `/kong`, then flip the flag on.

## Route audit note

The route audit stays green, but for `/kong` and the trigger routes its guarantee is now **structural** — it asserts a gate is *attached*, not that the gate rejects at runtime (the gate warns-and-allows while enforcement is off). That's why the startup warning exists.

## Setting the flag at startup

Read per request, so it takes effect immediately with no rebuild. Defaults to FALSE (permissive rollout). Set via:

- **Env var** (note the `PDP_` prefix): `PDP_ENFORCE_OPERATIONAL_ROUTE_AUTH=true`
  - Docker: `docker run -e PDP_ENFORCE_OPERATIONAL_ROUTE_AUTH=true permitio/pdp-v2:latest`
  - Kubernetes: add `{ name: PDP_ENFORCE_OPERATIONAL_ROUTE_AUTH, value: "true" }` to the container `env`.
- **Cloud control plane** — flip per-fleet without redeploying. Intended production path once the logs show every caller sends the token.

Leave it unset/false during the coordinated upgrade; flip to true only after the per-request warnings go quiet.

## Where to find the "would be rejected" logs

While the flag is off, would-be rejections are emitted through loguru at WARNING level, filterable by the string `ENFORCE_OPERATIONAL_ROUTE_AUTH`:

- **Startup, once:** confirms the fleet is in permissive mode.
- **Per request (coalesced):** identifies a specific caller not yet sending the token. When this stops across a representative window, it's safe to enforce.

Locations:
- **Container stdout — always on:** `docker logs <container> 2>&1 | grep ENFORCE_OPERATIONAL_ROUTE_AUTH` / `kubectl logs <pdp-pod> | grep ENFORCE_OPERATIONAL_ROUTE_AUTH`
- **Logz.io central drain — only if `CENTRAL_LOG_ENABLED=true`** with a valid token.
- **Datadog Logs** — if stdout is scraped: `service:permit-pdp "ENFORCE_OPERATIONAL_ROUTE_AUTH is off"`.

> **Note on branch history:** the toggle was briefly removed from this branch (commits `0ac5e89` / reverted in `0a35176`) while evaluating unconditional enforcement, then reinstated — the net diff is the toggle as described above.
