### PR TITLE
fix(docker): build custom OPA from ./cmd/opa when present (permit-opa per-12529 layout)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
   then \
     cd /custom && \
     tar xzf custom_opa.tar.gz && \
-    CGO_ENABLED=0 go build -a -ldflags="-s -w -extldflags=-static" -tags netgo -installsuffix netgo -o /opa && \
+    # permit-opa moved its main package from the repo root to ./cmd/opa
+    # (cmd/ + pkg/ layout); build whichever location the tarball provides
+    if [ -d cmd/opa ]; then main_pkg=./cmd/opa; else main_pkg=.; fi && \
+    CGO_ENABLED=0 go build -a -ldflags="-s -w -extldflags=-static" -tags netgo -installsuffix netgo -o /opa $main_pkg && \
     rm -rf /custom; \
   else \
     case $(uname -m) in \


### PR DESCRIPTION
## Why

permit-opa's `per-12529` branch ([permit-opa PR #33](https://github.com/permitio/permit-opa/pull/33)) moves its main package from the repo root to `./cmd/opa` (standard `cmd/` + `pkg/` layout). The `opa_build` stage here runs a bare `go build`, which compiles the package in the tarball root — once that branch merges to permit-opa `main`, the release/tests builds (which check out permit-opa `main` and tar its Go sources into `custom_opa.tar.gz`) fail with `no Go files in /custom`.

The tarball-creation side (`release.yml`, `tests.yml`, `build_opal_bundle.sh`) needs no change: its recursive `find` already picks up the sources under `cmd/` and `pkg/` with paths intact.

## What

Detect the layout inside the extracted tarball and build whichever main-package location it provides:

- `cmd/opa` exists → `go build ./cmd/opa` (new layout)
- otherwise → `go build .` (current root layout)

This makes the stage work against permit-opa `main` both **before and after** the per-12529 merge, so merge ordering can't break a release.

## Verification

Built the `opa_build` stage locally with `custom_opa.tar.gz` generated by the release workflow's exact `find` command from both permit-opa layouts:

- per-12529 branch (`cmd/`+`pkg/`): ✅ builds, `/opa version` → 1.14.1, binary contains the new `pkg/plugin/query_engine` packages
- current `main` (root layout): ✅ builds, `/opa version` → 1.14.1

## Merge plan

Draft until [permit-opa per-12529](https://github.com/permitio/permit-opa/pull/33) merges to main. (The conditional makes it safe to merge earlier if convenient, but keeping the ordering explicit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)