### PR TITLE
chore: drop the general-redoc ECS redeploy from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,21 +74,3 @@ jobs:
         tags: permitio/pdp-v2:${{ github.event.release.tag_name }},permitio/pdp-v2:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
-
-  update-pdp-api-ecs-service:
-    needs: build-and-push-pdp
-    runs-on: ubuntu-latest
-    if: "!github.event.release.prerelease"
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.PDP_CICD_AWS_ROLE }}
-          aws-region: us-east-1
-
-      - name: Redeploy ECS service - pdp-general-redoc-service
-        run: |
-          aws ecs update-service \
-            --cluster public-pdps-us-east-1 \
-            --service pdp-general-redoc-service-731a74c \
-            --force-new-deployment


### PR DESCRIPTION
## What

Removes the `update-pdp-api-ecs-service` job from `.github/workflows/release.yml`. One file, 18 deletions, nothing else changed.

## Why

general-redoc is being removed, so the job has nothing left to act on. Left in place it would start failing with `ServiceNotFoundException` on the first official release after the service is gone.

## What the job did

It force-redeployed exactly one ECS service after every official (non-prerelease) release:

```
aws ecs update-service --cluster public-pdps-us-east-1 \
  --service pdp-general-redoc-service-731a74c --force-new-deployment
```

The flag was necessary because that service is pinned to `image_tag = "latest"`. The tag string never changes, so no new task definition revision is created and nothing would otherwise pull the new image — `--force-new-deployment` re-runs the existing revision, which makes Fargate pull fresh.

## Consequence

**No PDP is auto-updated on release after this.** general-redoc was the only one wired into the release pipeline; every other hosted PDP is already refreshed out of band through pdp-deployer. Worth confirming that matches the intent before merging.

## Left behind on purpose

Both are direct consequences of this removal, but out of scope for a PR asked to remove one job. Happy to fold either in:

- **`permissions: id-token: write` (line 8) is now dead.** It existed solely for this job's OIDC auth, and no remaining job in the file assumes an AWS role. On a public repo it currently grants OIDC-minting ability to `build-and-push-pdp`, which handles Docker Hub credentials and runs third-party actions.
- **The `PDP_CICD_AWS_ROLE` secret now has no consumer in this repository.** `deploy_sidecar.yml` uses a different secret (`ROLE_ARN`) and is unaffected.

## Verification

- `release.yml` still parses; remaining jobs are `pdp-tests` and `build-and-push-pdp`, trigger unchanged.
- The only other `redoc` matches in the repo are ReDoc, the OpenAPI docs renderer — unrelated.
- Branch is cut fresh from `origin/main` and contains this one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
