### PR TITLE
feat(watchdog): optional child stdout/stderr capture via ChildOutputHandler

### DIFF
--- a/pdp-server/src/state.rs
+++ b/pdp-server/src/state.rs
@@ -36,7 +36,12 @@ struct HorizonOutput;
 
 impl ChildOutputHandler for HorizonOutput {
     fn on_line(&self, stream: ChildStream, line: &str) {
-        log::info!(target: "horizon", "[{stream}] {line}");
+        // Under the crate's own module path, not a bare "horizon": a
+        // target-scoped directive such as `RUST_LOG=pdp_server=debug`
+        // matches a target by prefix, so a bare "horizon" falls outside it
+        // and this output would silently vanish whenever verbosity is scoped
+        // to the crate rather than left global.
+        log::info!(target: "pdp_server::horizon", "[{stream}] {line}");
     }
 }
 
@@ -283,8 +288,9 @@ mod tests {
     }
 
     /// The handler must survive whatever the child writes: it runs on the task
-    /// that keeps the child's pipes drained, so a panic here stops the
-    /// draining and eventually blocks the child in `write`.
+    /// that keeps the child's pipes drained, so a panic here ends that task —
+    /// the child then either blocks on a full pipe or, once the read end
+    /// closes, dies on `SIGPIPE` and restart-loops.
     #[test]
     fn horizon_output_handler_survives_hostile_lines() {
         let handler = HorizonOutput;

--- a/pdp-server/src/state.rs
+++ b/pdp-server/src/state.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::process::Command;
 use watchdog::{
-    CommandWatchdogOptions, HttpHealthChecker, ServiceWatchdog, ServiceWatchdogOptions,
+    ChildOutputHandler, ChildStream, CommandWatchdogOptions, HttpHealthChecker, ServiceWatchdog,
+    ServiceWatchdogOptions,
 };
 
 /// Represents the application state containing shared resources and configurations
@@ -22,6 +23,21 @@ pub struct AppState {
     pub opa_client: Arc<Client>,
     pub horizon_client: Arc<Client>,
     pub trino_authz_config: Option<Arc<TrinoAuthzConfig>>,
+}
+
+/// Re-emits the supervised Horizon child's output on this process's logger,
+/// tagged so a reader can tell the child's lines from the server's own.
+///
+/// Both streams are logged at `info`. Uvicorn writes its ordinary startup and
+/// access lines to stderr, so treating stderr as a warning would misreport
+/// every healthy line as a problem; the stream name is recorded instead and
+/// left for the reader to interpret.
+struct HorizonOutput;
+
+impl ChildOutputHandler for HorizonOutput {
+    fn on_line(&self, stream: ChildStream, line: &str) {
+        log::info!(target: "horizon", "[{stream}] {line}");
+    }
 }
 
 impl AppState {
@@ -137,6 +153,7 @@ impl AppState {
             command_options: CommandWatchdogOptions {
                 restart_interval: Duration::from_secs(config.horizon.restart_interval),
                 termination_timeout: Duration::from_secs(config.horizon.termination_timeout),
+                output_handler: Some(Arc::new(HorizonOutput)),
             },
         };
 
@@ -263,5 +280,23 @@ mod tests {
         // Verify the clone is valid
         assert!(Arc::ptr_eq(&state.config, &cloned_state.config));
         assert!(Arc::ptr_eq(&state.cache, &cloned_state.cache));
+    }
+
+    /// The handler must survive whatever the child writes: it runs on the task
+    /// that keeps the child's pipes drained, so a panic here stops the
+    /// draining and eventually blocks the child in `write`.
+    #[test]
+    fn horizon_output_handler_survives_hostile_lines() {
+        let handler = HorizonOutput;
+        for line in [
+            "",
+            "INFO:     Uvicorn running on http://0.0.0.0:7001",
+            "{\"not\":\"a log line\"}",
+            "  \t  ",
+            &"x".repeat(64 * 1024),
+        ] {
+            handler.on_line(ChildStream::Stdout, line);
+            handler.on_line(ChildStream::Stderr, line);
+        }
     }
 }

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -10,7 +10,7 @@ A Rust library for monitoring and automatically restarting services and processe
 - **Configurable**: Customizable retry intervals, health check thresholds, and startup delays
 - **Statistics**: Track health checks, failures, and restarts
 - **Graceful Termination**: Uses SIGTERM with a configurable timeout before SIGKILL
-- **Child Output Capture**: optionally capture a child's stdout/stderr and receive it line by line, so its output can be attributed to the process that produced it
+- **Child Output Capture**: Optionally capture a child's stdout/stderr and receive it line by line, so its output can be attributed to the process that produced it
 
 ## Usage
 

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -10,6 +10,7 @@ A Rust library for monitoring and automatically restarting services and processe
 - **Configurable**: Customizable retry intervals, health check thresholds, and startup delays
 - **Statistics**: Track health checks, failures, and restarts
 - **Graceful Termination**: Uses SIGTERM with a configurable timeout before SIGKILL
+- **Child Output Capture**: optionally capture a child's stdout/stderr and receive it line by line, so its output can be attributed to the process that produced it
 
 ## Usage
 
@@ -32,6 +33,36 @@ let watchdog = CommandWatchdog::start(cmd);
 // You can also manually restart the process
 watchdog.restart().await.expect("Failed to restart process");
 ```
+
+### Capturing child output
+
+By default a watched child inherits the parent's stdout and stderr, so its
+output is indistinguishable from the parent's. Supply a `ChildOutputHandler` to
+receive it line by line instead:
+
+```rust
+use std::sync::Arc;
+use watchdog::{ChildOutputHandler, ChildStream, CommandWatchdog, CommandWatchdogOptions};
+
+struct LogLines;
+
+impl ChildOutputHandler for LogLines {
+    fn on_line(&self, stream: ChildStream, line: &str) {
+        log::info!("[my-service {stream}] {line}");
+    }
+}
+
+let opt = CommandWatchdogOptions {
+    output_handler: Some(Arc::new(LogLines)),
+    ..Default::default()
+};
+let watchdog = CommandWatchdog::start_with_opt(cmd, opt);
+```
+
+The handler runs on the task that keeps the child's pipes drained, so it must
+neither block nor panic: a pipe that stops being read fills its kernel buffer
+and the child then blocks in `write`. Lines longer than `MAX_LINE_BYTES`
+(16 KiB) are delivered truncated with `TRUNCATION_MARKER` appended.
 
 ### ServiceWatchdog
 

--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -59,10 +59,17 @@ let opt = CommandWatchdogOptions {
 let watchdog = CommandWatchdog::start_with_opt(cmd, opt);
 ```
 
-The handler runs on the task that keeps the child's pipes drained, so it must
-neither block nor panic: a pipe that stops being read fills its kernel buffer
-and the child then blocks in `write`. Lines longer than `MAX_LINE_BYTES`
-(16 KiB) are delivered truncated with `TRUNCATION_MARKER` appended.
+The handler runs on the task that keeps the child's pipes drained. Bounded,
+synchronous work — a line-buffered write through a logger, as above — is fine.
+What must not happen is `await`ing, an unbounded blocking call, or taking a lock
+some other task may hold for a long time: for as long as `on_line` has not
+returned, that task is not reading, and a pipe that stops being read fills its
+kernel buffer and the child then blocks in `write`. Panicking is worse than
+stalling — it drops the pipe handle, closing the read end, so a child that goes
+on writing takes `SIGPIPE` and dies.
+
+Lines longer than `MAX_LINE_BYTES` (16 KiB read from the child) are delivered
+truncated with `TRUNCATION_MARKER` appended.
 
 ### ServiceWatchdog
 

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -17,11 +17,13 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio_util::sync::CancellationToken;
 
 mod health;
+mod output;
 mod service;
 mod stats;
 
 // Re-export health checkers and service watchdog
 pub use health::{HealthCheck, HttpHealthChecker};
+pub use output::{ChildOutputHandler, ChildStream, MAX_LINE_BYTES, TRUNCATION_MARKER};
 pub use service::{ServiceWatchdog, ServiceWatchdogOptions};
 
 #[derive(Debug, Clone)]

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -54,9 +54,10 @@ pub struct CommandWatchdogOptions {
     /// line at a time to [`ChildOutputHandler::on_line`] — which is how a
     /// caller attributes a child's output to the process that produced it.
     ///
-    /// Note the obligations on the trait: the handler must neither block nor
-    /// panic, because it runs on the task that keeps the child's pipes
-    /// drained.
+    /// Note the obligations on the trait: the handler must not perform
+    /// unbounded blocking work or panic, because it runs on the task that
+    /// keeps the child's pipes drained. See [`ChildOutputHandler`]'s own doc
+    /// for what that does and does not rule out.
     pub output_handler: Option<Arc<dyn ChildOutputHandler>>,
 }
 
@@ -189,12 +190,15 @@ impl CommandWatchdog {
                 let mut child = match command.spawn() {
                     Ok(mut child) => {
                         // Attach a reader to each piped stream for THIS
-                        // generation. Both must always be read: a piped stream
-                        // nobody drains fills its kernel buffer and the child
-                        // then blocks in `write` forever, which looks exactly
-                        // like a hang. Each task ends at EOF — i.e. when this
-                        // generation exits — so nothing accumulates across
-                        // restarts.
+                        // generation. Both must always be read: once a piped
+                        // stream stops being drained, the child either blocks
+                        // in `write` on a full pipe (while the read end is
+                        // still open but nothing is taking from it) or, once
+                        // that read end actually closes, takes `SIGPIPE` and
+                        // dies — restart-looping either way, which looks
+                        // exactly like a hang until it does. Each reader task
+                        // ends at EOF — i.e. when this generation exits — so
+                        // nothing accumulates across restarts.
                         if let Some(handler) = opt.output_handler.clone() {
                             if let Some(stdout) = child.stdout.take() {
                                 tokio::spawn(crate::output::pump(

--- a/watchdog/src/lib.rs
+++ b/watchdog/src/lib.rs
@@ -40,12 +40,44 @@ pub struct CommandWatchdog {
     stats: Arc<CommandWatchdogStats>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CommandWatchdogOptions {
     /// Maximum duration between restarts from exits or failed boot (default: 1 s)
     pub restart_interval: Duration,
     /// Maximum time to wait for a process to terminate after kill signal (default: 60 s)
     pub termination_timeout: Duration,
+    /// Where the child's stdout and stderr go.
+    ///
+    /// `None` (the default) leaves both streams inheriting the parent's file
+    /// descriptors, which is what a watched process has always done. Supplying
+    /// a handler switches both to pipes the watchdog drains, delivering one
+    /// line at a time to [`ChildOutputHandler::on_line`] — which is how a
+    /// caller attributes a child's output to the process that produced it.
+    ///
+    /// Note the obligations on the trait: the handler must neither block nor
+    /// panic, because it runs on the task that keeps the child's pipes
+    /// drained.
+    pub output_handler: Option<Arc<dyn ChildOutputHandler>>,
+}
+
+// Hand-written rather than derived: `Arc<dyn ChildOutputHandler>` is not
+// `Debug`, and requiring `Debug` of every implementor is a worse trade than
+// printing whether one is installed.
+impl std::fmt::Debug for CommandWatchdogOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommandWatchdogOptions")
+            .field("restart_interval", &self.restart_interval)
+            .field("termination_timeout", &self.termination_timeout)
+            .field(
+                "output_handler",
+                &if self.output_handler.is_some() {
+                    "Some(<handler>)"
+                } else {
+                    "None"
+                },
+            )
+            .finish()
+    }
 }
 
 impl Default for CommandWatchdogOptions {
@@ -53,6 +85,7 @@ impl Default for CommandWatchdogOptions {
         Self {
             restart_interval: Duration::from_secs(1),
             termination_timeout: Duration::from_secs(60),
+            output_handler: None,
         }
     }
 }
@@ -80,6 +113,15 @@ impl CommandWatchdog {
     pub fn start_with_opt(mut command: Command, opt: CommandWatchdogOptions) -> Self {
         let shutdown_token = CancellationToken::new();
         command.kill_on_drop(true);
+
+        // Configure stdio ONCE, before the command is moved into the
+        // supervising task: the same `Command` is reused for every respawn, so
+        // this applies to each generation, and each `spawn()` creates its own
+        // fresh pair of pipes.
+        if opt.output_handler.is_some() {
+            command.stdout(std::process::Stdio::piped());
+            command.stderr(std::process::Stdio::piped());
+        }
 
         // For logging purposes, we extract the program name and command line string
         let program_name = command.as_std().get_program().to_string_lossy().to_string();
@@ -145,7 +187,32 @@ impl CommandWatchdog {
                 );
                 last_start_time = std::time::Instant::now();
                 let mut child = match command.spawn() {
-                    Ok(child) => child,
+                    Ok(mut child) => {
+                        // Attach a reader to each piped stream for THIS
+                        // generation. Both must always be read: a piped stream
+                        // nobody drains fills its kernel buffer and the child
+                        // then blocks in `write` forever, which looks exactly
+                        // like a hang. Each task ends at EOF — i.e. when this
+                        // generation exits — so nothing accumulates across
+                        // restarts.
+                        if let Some(handler) = opt.output_handler.clone() {
+                            if let Some(stdout) = child.stdout.take() {
+                                tokio::spawn(crate::output::pump(
+                                    stdout,
+                                    crate::ChildStream::Stdout,
+                                    handler.clone(),
+                                ));
+                            }
+                            if let Some(stderr) = child.stderr.take() {
+                                tokio::spawn(crate::output::pump(
+                                    stderr,
+                                    crate::ChildStream::Stderr,
+                                    handler,
+                                ));
+                            }
+                        }
+                        child
+                    }
                     Err(e) => {
                         info!("Failed to start process '{program_name}': {e}");
                         tokio::time::sleep(opt.restart_interval).await;

--- a/watchdog/src/output.rs
+++ b/watchdog/src/output.rs
@@ -79,9 +79,6 @@ pub const TRUNCATION_MARKER: &str = "…[truncated by watchdog]";
 ///
 /// `Eof` is distinct from an empty line: a child that writes a bare `\n`
 /// produced a line, and conflating the two would end the stream early.
-// Not yet called from outside `tests`: nothing routes a child's pipes through
-// this reader yet.
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ReadOutcome {
     Eof,
@@ -93,9 +90,6 @@ pub(crate) enum ReadOutcome {
 /// newline.
 ///
 /// The trailing `\n` is not appended. `out` is expected to be empty on entry.
-// Not yet called from outside `tests`: nothing routes a child's pipes through
-// this reader yet.
-#[allow(dead_code)]
 pub(crate) async fn read_line_bounded<R: AsyncBufRead + Unpin>(
     reader: &mut R,
     out: &mut Vec<u8>,
@@ -131,8 +125,6 @@ pub(crate) async fn read_line_bounded<R: AsyncBufRead + Unpin>(
 /// Append `chunk` to `out`, stopping at [`MAX_LINE_BYTES`] and setting
 /// `truncated` if anything had to be dropped. Bytes beyond the cap are
 /// discarded rather than buffered, which is what bounds memory.
-// Not yet called from outside `tests` (transitively, via `read_line_bounded`).
-#[allow(dead_code)]
 fn append_bounded(out: &mut Vec<u8>, chunk: &[u8], truncated: &mut bool) {
     let room = MAX_LINE_BYTES.saturating_sub(out.len());
     if chunk.len() > room {
@@ -146,9 +138,6 @@ fn append_bounded(out: &mut Vec<u8>, chunk: &[u8], truncated: &mut bool) {
 /// Returns when the stream ends, which for a child's pipe is when that
 /// generation of the child exits — so each spawn's reader task retires on its
 /// own and nothing accumulates across restarts.
-// Not yet called from outside `tests`: nothing spawns a reader task against
-// this function yet.
-#[allow(dead_code)]
 pub(crate) async fn pump<R: AsyncRead + Unpin>(
     reader: R,
     stream: ChildStream,

--- a/watchdog/src/output.rs
+++ b/watchdog/src/output.rs
@@ -45,19 +45,27 @@ impl std::fmt::Display for ChildStream {
 /// switches the child from inheriting the parent's file descriptors to pipes
 /// the watchdog drains.
 ///
-/// # Implementations must not block
+/// # Bounded work is fine; unbounded blocking is not
 ///
-/// `on_line` is called from the task that keeps the child's pipe drained. A
-/// pipe that stops being read fills its kernel buffer (~64 KiB on Linux) and
-/// the child then blocks in `write` indefinitely — which presents as a hung
+/// `on_line` is called from the task that keeps the child's pipe drained.
+/// Bounded, synchronous work — a line-buffered write through a logger, which
+/// is the expected implementation — does not meaningfully stall this seam.
+/// What must not happen is `await`ing, an unbounded blocking call, or taking
+/// a lock some other task may hold for a long time: for as long as `on_line`
+/// has not returned, this task is not reading, and a pipe that stops being
+/// read fills its kernel buffer (~64 KiB on Linux) and the child then blocks
+/// in `write` for as long as the stall lasts — which presents as a hung
 /// process and, under [`ServiceWatchdog`](crate::ServiceWatchdog), a failed
-/// health check and a restart loop. Do no blocking I/O and take no contended
-/// lock here.
+/// health check and a restart loop.
 ///
 /// # Implementations must not panic
 ///
-/// A panic kills the reader task, which stops the draining, with the same
-/// consequence. Handle every malformed input rather than unwrapping.
+/// A panic kills the reader task outright, which is a different failure from
+/// a stall: the task ending drops the `BufReader` and the pipe handle it
+/// owns, closing the read end. A child that goes on writing to that fd no
+/// longer blocks — it takes `SIGPIPE` and dies, and the supervisor
+/// restart-loops it. Either way draining has stopped and the child is in
+/// trouble, so handle every malformed input rather than unwrapping.
 pub trait ChildOutputHandler: Send + Sync + 'static {
     fn on_line(&self, stream: ChildStream, line: &str);
 }
@@ -149,9 +157,14 @@ pub(crate) async fn pump<R: AsyncRead + Unpin>(
         buf.clear();
         let outcome = match read_line_bounded(&mut reader, &mut buf).await {
             Ok(outcome) => outcome,
-            // A read error on a child's pipe means the pipe is gone. There is
-            // nothing to recover and nowhere to report it that would not risk
-            // a loop, so stop draining this stream.
+            // `Interrupted` is transient (e.g. a delivered signal) and
+            // `BufReader::fill_buf` does not retry it internally — retry it
+            // here instead, so one signal does not permanently blind this
+            // stream.
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            // Any other read error on a child's pipe means the pipe is gone.
+            // There is nothing to recover and nowhere to report it that would
+            // not risk a loop, so stop draining this stream.
             Err(_) => return,
         };
         match outcome {
@@ -332,5 +345,61 @@ mod tests {
                 .expect("read"),
             ReadOutcome::Eof
         ));
+    }
+
+    /// `ErrorKind::Interrupted` is transient (e.g. a delivered signal), and
+    /// `AsyncBufReadExt::fill_buf` does not retry it internally. `pump` must,
+    /// so one signal cannot permanently blind the stream.
+    #[tokio::test]
+    async fn an_interrupted_read_is_retried_not_treated_as_fatal() {
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use tokio::io::ReadBuf;
+
+        /// An `AsyncRead` that fails once with `Interrupted`, then reads out
+        /// `data` normally.
+        struct FlakyOnce {
+            errored: bool,
+            data: &'static [u8],
+            pos: usize,
+        }
+
+        impl AsyncRead for FlakyOnce {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &mut ReadBuf<'_>,
+            ) -> Poll<std::io::Result<()>> {
+                if !self.errored {
+                    self.errored = true;
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "simulated signal",
+                    )));
+                }
+                let remaining = &self.data[self.pos..];
+                let n = remaining.len().min(buf.remaining());
+                buf.put_slice(&remaining[..n]);
+                self.pos += n;
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        let collector = Arc::new(Collector::default());
+        pump(
+            FlakyOnce {
+                errored: false,
+                data: b"after the blip\n",
+                pos: 0,
+            },
+            ChildStream::Stdout,
+            collector.clone(),
+        )
+        .await;
+        assert_eq!(
+            collector.lines(),
+            vec![(ChildStream::Stdout, "after the blip".to_string())],
+            "a transient Interrupted error must not end the stream"
+        );
     }
 }

--- a/watchdog/src/output.rs
+++ b/watchdog/src/output.rs
@@ -1,0 +1,347 @@
+//! Capturing a supervised child's stdout/stderr.
+//!
+//! By default a watched child inherits the parent's file descriptors, so its
+//! output goes straight to the parent's own stdout/stderr with nothing to say
+//! which process produced it. Supplying a
+//! [`ChildOutputHandler`](crate::CommandWatchdogOptions::output_handler)
+//! switches those two streams to pipes that the watchdog drains, handing the
+//! caller one line at a time.
+//!
+//! The watchdog deliberately does no interpretation: it splits on `\n`, bounds
+//! the line length, lossily decodes UTF-8, and passes the result on. What a
+//! line *means* — its severity, its structure — is the caller's business,
+//! because only the caller knows which program it started.
+
+use std::sync::Arc;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, BufReader};
+
+/// Which of a supervised child's two output streams a line came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChildStream {
+    Stdout,
+    Stderr,
+}
+
+impl ChildStream {
+    /// A stable, lowercase name suitable for use as a log field value.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+impl std::fmt::Display for ChildStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Receives each line a supervised child writes to stdout or stderr.
+///
+/// Supplying a handler through
+/// [`CommandWatchdogOptions::output_handler`](crate::CommandWatchdogOptions::output_handler)
+/// switches the child from inheriting the parent's file descriptors to pipes
+/// the watchdog drains.
+///
+/// # Implementations must not block
+///
+/// `on_line` is called from the task that keeps the child's pipe drained. A
+/// pipe that stops being read fills its kernel buffer (~64 KiB on Linux) and
+/// the child then blocks in `write` indefinitely — which presents as a hung
+/// process and, under [`ServiceWatchdog`](crate::ServiceWatchdog), a failed
+/// health check and a restart loop. Do no blocking I/O and take no contended
+/// lock here.
+///
+/// # Implementations must not panic
+///
+/// A panic kills the reader task, which stops the draining, with the same
+/// consequence. Handle every malformed input rather than unwrapping.
+pub trait ChildOutputHandler: Send + Sync + 'static {
+    fn on_line(&self, stream: ChildStream, line: &str);
+}
+
+/// Longest line handed to a [`ChildOutputHandler`], in bytes.
+///
+/// A child is free to write a gigabyte without ever emitting a newline, and a
+/// reader that simply accumulated until one arrived would let it grow the
+/// supervising process's memory without limit. Lines longer than this are
+/// delivered truncated, marked with [`TRUNCATION_MARKER`], and the reader then
+/// resynchronises on the next newline.
+pub const MAX_LINE_BYTES: usize = 16 * 1024;
+
+/// Appended to a line that hit [`MAX_LINE_BYTES`], so a reader of the log can
+/// tell a truncated line from a complete one.
+pub const TRUNCATION_MARKER: &str = "…[truncated by watchdog]";
+
+/// What [`read_line_bounded`] found.
+///
+/// `Eof` is distinct from an empty line: a child that writes a bare `\n`
+/// produced a line, and conflating the two would end the stream early.
+// Not yet called from outside `tests`: nothing routes a child's pipes through
+// this reader yet.
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReadOutcome {
+    Eof,
+    Line { truncated: bool },
+}
+
+/// Read one `\n`-terminated line into `out`, appending at most
+/// [`MAX_LINE_BYTES`] and discarding any excess up to and including the
+/// newline.
+///
+/// The trailing `\n` is not appended. `out` is expected to be empty on entry.
+// Not yet called from outside `tests`: nothing routes a child's pipes through
+// this reader yet.
+#[allow(dead_code)]
+pub(crate) async fn read_line_bounded<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    out: &mut Vec<u8>,
+) -> std::io::Result<ReadOutcome> {
+    let mut truncated = false;
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            // EOF. Anything already buffered is a final, unterminated line —
+            // often the very message that explains why the child exited, so it
+            // must not be dropped.
+            return Ok(if out.is_empty() {
+                ReadOutcome::Eof
+            } else {
+                ReadOutcome::Line { truncated }
+            });
+        }
+        match available.iter().position(|&b| b == b'\n') {
+            Some(idx) => {
+                append_bounded(out, &available[..idx], &mut truncated);
+                reader.consume(idx + 1);
+                return Ok(ReadOutcome::Line { truncated });
+            }
+            None => {
+                let len = available.len();
+                append_bounded(out, available, &mut truncated);
+                reader.consume(len);
+            }
+        }
+    }
+}
+
+/// Append `chunk` to `out`, stopping at [`MAX_LINE_BYTES`] and setting
+/// `truncated` if anything had to be dropped. Bytes beyond the cap are
+/// discarded rather than buffered, which is what bounds memory.
+// Not yet called from outside `tests` (transitively, via `read_line_bounded`).
+#[allow(dead_code)]
+fn append_bounded(out: &mut Vec<u8>, chunk: &[u8], truncated: &mut bool) {
+    let room = MAX_LINE_BYTES.saturating_sub(out.len());
+    if chunk.len() > room {
+        *truncated = true;
+    }
+    out.extend_from_slice(&chunk[..room.min(chunk.len())]);
+}
+
+/// Drain `reader` to EOF, handing each line to `handler`.
+///
+/// Returns when the stream ends, which for a child's pipe is when that
+/// generation of the child exits — so each spawn's reader task retires on its
+/// own and nothing accumulates across restarts.
+// Not yet called from outside `tests`: nothing spawns a reader task against
+// this function yet.
+#[allow(dead_code)]
+pub(crate) async fn pump<R: AsyncRead + Unpin>(
+    reader: R,
+    stream: ChildStream,
+    handler: Arc<dyn ChildOutputHandler>,
+) {
+    let mut reader = BufReader::new(reader);
+    let mut buf = Vec::with_capacity(256);
+    loop {
+        buf.clear();
+        let outcome = match read_line_bounded(&mut reader, &mut buf).await {
+            Ok(outcome) => outcome,
+            // A read error on a child's pipe means the pipe is gone. There is
+            // nothing to recover and nowhere to report it that would not risk
+            // a loop, so stop draining this stream.
+            Err(_) => return,
+        };
+        match outcome {
+            ReadOutcome::Eof => return,
+            ReadOutcome::Line { truncated } => {
+                // A child writing CRLF would otherwise leave a stray control
+                // character at the end of every message.
+                let bytes = match buf.last() {
+                    Some(b'\r') => &buf[..buf.len() - 1],
+                    _ => &buf[..],
+                };
+                let mut line = String::from_utf8_lossy(bytes).into_owned();
+                if truncated {
+                    line.push_str(TRUNCATION_MARKER);
+                }
+                handler.on_line(stream, &line);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::BufReader;
+
+    /// Collects everything a handler is given, so a test can assert on the
+    /// exact sequence of (stream, line) pairs.
+    #[derive(Default)]
+    struct Collector(Mutex<Vec<(ChildStream, String)>>);
+
+    impl ChildOutputHandler for Collector {
+        fn on_line(&self, stream: ChildStream, line: &str) {
+            self.0
+                .lock()
+                .expect("lock")
+                .push((stream, line.to_string()));
+        }
+    }
+
+    impl Collector {
+        fn lines(&self) -> Vec<(ChildStream, String)> {
+            self.0.lock().expect("lock").clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn splits_on_newlines_and_strips_them() {
+        let collector = Arc::new(Collector::default());
+        pump(
+            &b"one\ntwo\nthree\n"[..],
+            ChildStream::Stdout,
+            collector.clone(),
+        )
+        .await;
+        assert_eq!(
+            collector.lines(),
+            vec![
+                (ChildStream::Stdout, "one".to_string()),
+                (ChildStream::Stdout, "two".to_string()),
+                (ChildStream::Stdout, "three".to_string()),
+            ]
+        );
+    }
+
+    /// A child that exits without a trailing newline must not have its last
+    /// line swallowed — that line is often the panic or usage error which
+    /// explains why it exited.
+    #[tokio::test]
+    async fn a_final_unterminated_line_is_still_delivered() {
+        let collector = Arc::new(Collector::default());
+        pump(
+            &b"first\nlast without newline"[..],
+            ChildStream::Stderr,
+            collector.clone(),
+        )
+        .await;
+        assert_eq!(
+            collector.lines(),
+            vec![
+                (ChildStream::Stderr, "first".to_string()),
+                (ChildStream::Stderr, "last without newline".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_stream_yields_no_lines() {
+        let collector = Arc::new(Collector::default());
+        pump(&b""[..], ChildStream::Stdout, collector.clone()).await;
+        assert!(collector.lines().is_empty());
+    }
+
+    /// A trailing `\r` from a child that writes CRLF must not become part of
+    /// the message, or every line ends in a stray control character.
+    #[tokio::test]
+    async fn a_trailing_carriage_return_is_stripped() {
+        let collector = Arc::new(Collector::default());
+        pump(
+            &b"crlf line\r\n"[..],
+            ChildStream::Stdout,
+            collector.clone(),
+        )
+        .await;
+        assert_eq!(
+            collector.lines(),
+            vec![(ChildStream::Stdout, "crlf line".to_string())]
+        );
+    }
+
+    /// The whole point of the cap: one child line that never terminates must
+    /// not be able to grow the supervisor's memory. The over-long line is
+    /// delivered truncated, and the stream keeps working afterwards.
+    #[tokio::test]
+    async fn an_over_long_line_is_truncated_and_the_stream_recovers() {
+        let mut input = vec![b'x'; MAX_LINE_BYTES * 3];
+        input.extend_from_slice(b"\nnext line\n");
+        let collector = Arc::new(Collector::default());
+        pump(&input[..], ChildStream::Stdout, collector.clone()).await;
+
+        let lines = collector.lines();
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected the truncated line then the next one, got {lines:?}"
+        );
+        assert!(
+            lines[0].1.len() <= MAX_LINE_BYTES + TRUNCATION_MARKER.len(),
+            "truncated line must be bounded, got {} bytes",
+            lines[0].1.len()
+        );
+        assert!(
+            lines[0].1.ends_with(TRUNCATION_MARKER),
+            "a truncated line must say so, got {:?}",
+            lines[0].1
+        );
+        assert_eq!(
+            lines[1].1, "next line",
+            "the reader must resynchronise on the next newline rather than \
+             emitting the discarded remainder as its own line"
+        );
+    }
+
+    /// A child may write arbitrary bytes (a binary blob, a broken locale). It
+    /// must not silence the stream.
+    #[tokio::test]
+    async fn invalid_utf8_is_lossily_decoded_not_dropped() {
+        let collector = Arc::new(Collector::default());
+        pump(
+            &b"before \xff\xfe after\n"[..],
+            ChildStream::Stderr,
+            collector.clone(),
+        )
+        .await;
+        let lines = collector.lines();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].1.starts_with("before "), "got {:?}", lines[0].1);
+        assert!(lines[0].1.ends_with(" after"), "got {:?}", lines[0].1);
+    }
+
+    #[tokio::test]
+    async fn read_line_bounded_reports_eof_separately_from_an_empty_line() {
+        let mut reader = BufReader::new(&b"\n"[..]);
+        let mut out = Vec::new();
+        assert!(matches!(
+            read_line_bounded(&mut reader, &mut out)
+                .await
+                .expect("read"),
+            ReadOutcome::Line { truncated: false }
+        ));
+        assert!(out.is_empty(), "an empty line is an empty line, not EOF");
+
+        out.clear();
+        assert!(matches!(
+            read_line_bounded(&mut reader, &mut out)
+                .await
+                .expect("read"),
+            ReadOutcome::Eof
+        ));
+    }
+}

--- a/watchdog/src/output.rs
+++ b/watchdog/src/output.rs
@@ -70,13 +70,20 @@ pub trait ChildOutputHandler: Send + Sync + 'static {
     fn on_line(&self, stream: ChildStream, line: &str);
 }
 
-/// Longest line handed to a [`ChildOutputHandler`], in bytes.
+/// Most bytes read from the child for a single line.
 ///
 /// A child is free to write a gigabyte without ever emitting a newline, and a
 /// reader that simply accumulated until one arrived would let it grow the
 /// supervising process's memory without limit. Lines longer than this are
 /// delivered truncated, marked with [`TRUNCATION_MARKER`], and the reader then
 /// resynchronises on the next newline.
+///
+/// This bounds the bytes taken off the pipe, which is not the same as the
+/// length of the `&str` the handler receives. Decoding is lossy, and each
+/// invalid byte becomes a U+FFFD costing three, so a line of entirely invalid
+/// UTF-8 arrives about three times this long. Memory stays bounded either way
+/// — one line at a time, at a fixed multiple of this constant — but a handler
+/// budgeting on the delivered length should budget for 3x.
 pub const MAX_LINE_BYTES: usize = 16 * 1024;
 
 /// Appended to a line that hit [`MAX_LINE_BYTES`], so a reader of the log can

--- a/watchdog/src/output.rs
+++ b/watchdog/src/output.rs
@@ -2,8 +2,8 @@
 //!
 //! By default a watched child inherits the parent's file descriptors, so its
 //! output goes straight to the parent's own stdout/stderr with nothing to say
-//! which process produced it. Supplying a
-//! [`ChildOutputHandler`](crate::CommandWatchdogOptions::output_handler)
+//! which process produced it. Supplying a [`ChildOutputHandler`] through
+//! [`CommandWatchdogOptions::output_handler`](crate::CommandWatchdogOptions::output_handler)
 //! switches those two streams to pipes that the watchdog drains, handing the
 //! caller one line at a time.
 //!

--- a/watchdog/tests/output.rs
+++ b/watchdog/tests/output.rs
@@ -1,0 +1,138 @@
+//! Child output capture, driven through real child processes.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::process::Command;
+use watchdog::{ChildOutputHandler, ChildStream, CommandWatchdog, CommandWatchdogOptions};
+
+#[derive(Default)]
+struct Collector(Mutex<Vec<(ChildStream, String)>>);
+
+impl ChildOutputHandler for Collector {
+    fn on_line(&self, stream: ChildStream, line: &str) {
+        self.0
+            .lock()
+            .expect("lock")
+            .push((stream, line.to_string()));
+    }
+}
+
+impl Collector {
+    fn lines(&self) -> Vec<(ChildStream, String)> {
+        self.0.lock().expect("lock").clone()
+    }
+    fn texts(&self) -> Vec<String> {
+        self.lines().into_iter().map(|(_, line)| line).collect()
+    }
+}
+
+/// A shell command is used rather than a fixture binary so the test depends on
+/// nothing but a POSIX shell.
+fn sh(script: &str) -> Command {
+    let mut cmd = Command::new("/bin/sh");
+    cmd.arg("-c").arg(script);
+    cmd
+}
+
+/// Poll rather than sleep a fixed amount: the child is a process, so how long
+/// it takes to produce output is not something a test can assume.
+async fn wait_for(collector: &Collector, want: usize, label: &str) {
+    for _ in 0..200 {
+        if collector.lines().len() >= want {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!(
+        "{label}: expected at least {want} lines, got {:?}",
+        collector.lines()
+    );
+}
+
+#[tokio::test]
+async fn both_streams_are_captured_and_attributed() {
+    let collector = Arc::new(Collector::default());
+    let opt = CommandWatchdogOptions {
+        // The child exits immediately, so keep the restart interval long
+        // enough that a second generation cannot muddy the assertion.
+        restart_interval: Duration::from_secs(30),
+        output_handler: Some(collector.clone()),
+        ..Default::default()
+    };
+    let _watchdog = CommandWatchdog::start_with_opt(sh("echo to-stdout; echo to-stderr >&2"), opt);
+
+    wait_for(&collector, 2, "both streams").await;
+
+    let lines = collector.lines();
+    assert!(
+        lines.contains(&(ChildStream::Stdout, "to-stdout".to_string())),
+        "stdout line missing or misattributed: {lines:?}"
+    );
+    assert!(
+        lines.contains(&(ChildStream::Stderr, "to-stderr".to_string())),
+        "stderr line missing or misattributed: {lines:?}"
+    );
+}
+
+/// The watchdog respawns the child, and each spawn creates fresh pipes. If the
+/// readers were attached once rather than per spawn, the second generation's
+/// output would vanish.
+#[tokio::test]
+async fn output_is_captured_across_a_restart() {
+    let collector = Arc::new(Collector::default());
+    let opt = CommandWatchdogOptions {
+        restart_interval: Duration::from_millis(50),
+        output_handler: Some(collector.clone()),
+        ..Default::default()
+    };
+    let _watchdog = CommandWatchdog::start_with_opt(sh("echo generation"), opt);
+
+    wait_for(&collector, 3, "restart generations").await;
+
+    let texts = collector.texts();
+    assert!(
+        texts.iter().filter(|line| *line == "generation").count() >= 3,
+        "each respawned generation must have its output captured, got {texts:?}"
+    );
+}
+
+/// A child that writes a very long line must not be able to grow the
+/// supervisor without bound, and must not take the rest of the stream with it.
+#[tokio::test]
+async fn an_over_long_child_line_is_truncated_and_the_stream_survives() {
+    let collector = Arc::new(Collector::default());
+    let opt = CommandWatchdogOptions {
+        restart_interval: Duration::from_secs(30),
+        output_handler: Some(collector.clone()),
+        ..Default::default()
+    };
+    // 200_000 `x`, well past MAX_LINE_BYTES, then a normal line.
+    let _watchdog = CommandWatchdog::start_with_opt(
+        sh("awk 'BEGIN { while (i++ < 200000) printf \"x\" ; print \"\" }'; echo after"),
+        opt,
+    );
+
+    wait_for(&collector, 2, "truncation").await;
+
+    let texts = collector.texts();
+    assert!(
+        texts[0].len() <= watchdog::MAX_LINE_BYTES + watchdog::TRUNCATION_MARKER.len(),
+        "the long line must be bounded, got {} bytes",
+        texts[0].len()
+    );
+    assert!(
+        texts[0].ends_with(watchdog::TRUNCATION_MARKER),
+        "a truncated line must say so"
+    );
+    assert!(
+        texts.contains(&"after".to_string()),
+        "the stream must survive a truncated line, got {texts:?}"
+    );
+}
+
+/// The default must stay behaviour-preserving: no handler means the child
+/// keeps inheriting the parent's file descriptors, exactly as before.
+#[test]
+fn the_default_supplies_no_handler() {
+    assert!(CommandWatchdogOptions::default().output_handler.is_none());
+}

--- a/watchdog/tests/output.rs
+++ b/watchdog/tests/output.rs
@@ -1,4 +1,8 @@
 //! Child output capture, driven through real child processes.
+//!
+//! Unix-only: every test here drives a child through a POSIX shell, and the
+//! crate itself already forks its termination path on `cfg(unix)`.
+#![cfg(unix)]
 
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -27,9 +31,13 @@ impl Collector {
 }
 
 /// A shell command is used rather than a fixture binary so the test depends on
-/// nothing but a POSIX shell.
+/// nothing but a POSIX shell — no fixture to build, and no `awk` or other
+/// external the script would otherwise reach for.
+///
+/// `sh` is resolved through `PATH` rather than hard-coded to `/bin/sh`, which
+/// is not where every Unix keeps it (some Nix setups among them).
 fn sh(script: &str) -> Command {
-    let mut cmd = Command::new("/bin/sh");
+    let mut cmd = Command::new("sh");
     cmd.arg("-c").arg(script);
     cmd
 }
@@ -106,9 +114,14 @@ async fn an_over_long_child_line_is_truncated_and_the_stream_survives() {
         output_handler: Some(collector.clone()),
         ..Default::default()
     };
-    // 200_000 `x`, well past MAX_LINE_BYTES, then a normal line.
+    // 2^18 = 262_144 `x`, well past MAX_LINE_BYTES, then a normal line.
+    // Built by doubling rather than with `awk`: it keeps this file's only
+    // dependency a POSIX shell, and 18 doublings beat a 262k-iteration loop.
     let _watchdog = CommandWatchdog::start_with_opt(
-        sh("awk 'BEGIN { while (i++ < 200000) printf \"x\" ; print \"\" }'; echo after"),
+        sh(
+            "s=x; i=0; while [ $i -lt 18 ]; do s=$s$s; i=$((i+1)); done; \
+            printf '%s\\n' \"$s\"; echo after",
+        ),
         opt,
     );
 

--- a/watchdog/tests/tests.rs
+++ b/watchdog/tests/tests.rs
@@ -175,6 +175,7 @@ async fn test_watchdog_termination_timeout() {
     let opt = CommandWatchdogOptions {
         restart_interval: Duration::from_millis(100),
         termination_timeout: Duration::from_millis(500),
+        ..Default::default()
     };
     let watchdog = CommandWatchdog::start_with_opt(test_server.get_command(), opt);
     tokio::time::sleep(Duration::from_millis(300)).await;


### PR DESCRIPTION
## The problem

A process supervised by `watchdog` inherits the parent's stdout and stderr. Its output therefore lands in the same stream as the supervisor's own, with nothing to say which process wrote any given line.

That cannot be fixed from outside the library. `CommandWatchdog` owns the respawn loop: it holds the `Command`, spawns it, and re-spawns it on exit, all inside a detached task. A caller never holds a `Child` whose pipes it could read.

## What this adds

An opt-in seam, `CommandWatchdogOptions::output_handler`:

```rust
pub trait ChildOutputHandler: Send + Sync + 'static {
    fn on_line(&self, stream: ChildStream, line: &str);
}
```

`None` — the `Default` — leaves both streams inheriting the parent's file descriptors, exactly as before. Supplying a handler switches them to pipes the watchdog drains, delivering one line at a time.

The watchdog does no interpretation: it splits on `\n`, bounds the line length, lossily decodes UTF-8, and passes the result on. What a line *means* — its severity, its structure — is the caller's business, because only the caller knows which program it started.

`pdp-server`'s supervised Horizon child is wired through it, so the API ships with a real consumer rather than as speculative surface.

## Details worth review attention

- **Draining is mandatory, not a nicety.** A piped stream nobody reads fills its kernel pipe buffer and the child then blocks in `write` forever — which presents as a hung process and, under `ServiceWatchdog`, a failed health check and a restart loop. Both pipes are always read.
- **Readers are created per spawn.** Each respawn makes fresh pipes; a reader attached once would silently lose every generation after the first. Reader tasks end at EOF — i.e. when their generation exits — so nothing accumulates across restarts.
- **Lines are bounded.** `AsyncBufReadExt::lines()` grows its buffer without limit on a stream that never emits `\n`, so the reader uses `read_until` against a 16 KiB cap. Over-long lines are delivered truncated and marked, and the reader resynchronises on the next newline. A final unterminated line is still delivered — it is usually the message explaining why the child exited.
- **Adding the field is source-breaking** for exhaustive struct-literal construction. That is deliberate: a compile error at each call site beats a field that can be silently forgotten. Both in-tree constructors are updated in this PR.

## Testing

- 7 unit tests over the reader (newline splitting, final unterminated line, empty stream, CRLF, over-cap truncation and resync, lossy UTF-8, EOF vs. empty line).
- 4 integration tests over real child processes: both streams captured and attributed, output captured across a restart, an over-long line truncated with the stream surviving, and the default supplying no handler.
- No new dependencies — `tokio` is already on `features = ["full"]`.

The pre-existing timing flakiness in `watchdog/tests/tests.rs` reproduces on unmodified `main`; it is not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)