### PR TITLE
build(docker): move the OPA builder to golang:1.26-bookworm (PER-15358)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,29 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # OPA BUILD STAGE -----------------------------------
 # Build OPA from source or download precompiled binary
 # ---------------------------------------------------
-FROM golang:1.25-bookworm AS opa_build
+# Go 1.26 is required ahead of permit-opa moving its `go` directive to 1.26.0.
+# That move is forced by golang.org/x/crypto v0.56.0 (the version that clears
+# CVE-2026-78662 / CVE-2026-56855 / CVE-2026-56854), whose own go.mod declares
+# `go 1.26.0`.
+#
+# This bump lands BEFORE the permit-opa change on purpose. tests.yml and
+# release.yml both check out permitio/permit-opa at `ref: main` with no pin, so
+# the moment that directive moves, every PDP build here compiles a `go 1.26.0`
+# module. The official golang images ship `ENV GOTOOLCHAIN=local`, so a
+# golang:1.25 builder does not quietly fetch a newer toolchain - it hard-fails:
+#
+#   go: go.mod requires go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)
+#
+# That breaks build-pdp-image on every PDP PR, every push to main and every
+# release cut until this lands. A golang:1.26 builder compiling today's
+# `go 1.25.0` module is forward-compatible, so the ordering is safe in one
+# direction only.
+#
+# Floats the patch version deliberately; the tag currently serves 1.26.8. Do not
+# pin below 1.26.6 - that is the floor carrying the toolchain-level fixes for
+# GO-2026-6090 (crypto/tls), GO-2026-5856 (ECH) and GO-2026-4918 (http2).
+# See PER-15358.
+FROM golang:1.26-bookworm AS opa_build
 
 COPY custom* /custom
 


### PR DESCRIPTION
build(docker): move the OPA builder to golang:1.26-bookworm (PER-15358)

Lands ahead of permit-opa raising its `go` directive to 1.26.0, which
golang.org/x/crypto v0.56.0 forces (that is the version clearing
CVE-2026-78662, CVE-2026-56855 and CVE-2026-56854).

Ordering matters and only works one way. tests.yml and release.yml both
check out permitio/permit-opa at `ref: main` with no pin, so a permit-opa
merge takes effect on the very next PDP build. The official golang images
ship `ENV GOTOOLCHAIN=local`, so a golang:1.25 builder facing a
`go 1.26.0` module does not fall back to downloading a toolchain - it
hard-fails:

    go: go.mod requires go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)

Verified by running the real permit-opa tree through golang:1.25-bookworm.
Without this PR, build-pdp-image breaks on every PDP PR, every push to main
and every release cut from the moment the permit-opa change merges. The
reverse (a 1.26 builder on today's `go 1.25.0` module) is forward-compatible.

The tag currently serves go1.26.8, verified by pulling it. Floor is 1.26.6 -
the release carrying the toolchain fixes for GO-2026-6090, GO-2026-5856 and
GO-2026-4918.

Verified end to end: the PDP's opa_build stage builds the bumped permit-opa
through this image and `opa version` reports 1.14.1 / go1.26.8.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>



---

## Merge order (3 PRs, PER-15358)

1. **permitio/PDP#334 — this PR.** Builder only. Green on its own, no runtime change.
2. **permitio/permit-opa#48** — the actual CVE fixes. Cannot merge before this one without hard-failing `build-pdp-image` everywhere.
3. **permitio/PDP#335** — arms the release gate + VEX corrections. Must be last: it makes the gate release-blocking, and the gate reports 4 HIGH until #48 lands.
