### PR TITLE
fix(ci): scan release builds, unpin VEX from :next, correct waivers (PER-15358)

### DIFF
--- a/.docker/scout/pdp-v2.vex.json
+++ b/.docker/scout/pdp-v2.vex.json
@@ -2,8 +2,8 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/permitio-pdp/pdp-v2-cve-waivers",
   "author": "Permit.io",
-  "timestamp": "2026-07-29T00:00:00Z",
-  "version": 4,
+  "timestamp": "2026-09-06T00:00:00Z",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -11,7 +11,7 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
             { "@id": "pkg:pypi/starlette@0.50.0" }
           ]
@@ -19,7 +19,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-48818 is an SSRF / NTLM credential-theft issue in starlette.staticfiles that only triggers on Windows, via UNC-path resolution when serving a StaticFiles mount. The PDP runs exclusively on Linux (Alpine) and mounts no StaticFiles anywhere in the app (only API routers are mounted), so the vulnerable code path is never present or executed. The fix lands only in starlette >= 1.1.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-48818 is an SSRF / NTLM credential-theft issue in starlette.staticfiles that only triggers on Windows, via UNC-path resolution when serving a StaticFiles mount. The PDP runs exclusively on Linux (Alpine) and mounts no StaticFiles anywhere in the image - verified across horizon/, pdp-server/, and every installed package including opal-client and opal-common 0.9.6, where the only StaticFiles occurrence is starlette's own module. The single .mount() call in the repo is in horizon/tests/, which .dockerignore excludes from the image, and it mounts a bare FastAPI app rather than StaticFiles. The vulnerable code path is therefore never present or executed. The fix lands only in starlette >= 1.1.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
     },
     {
       "vulnerability": {
@@ -27,7 +27,7 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
             { "@id": "pkg:pypi/starlette@0.50.0" }
           ]
@@ -35,7 +35,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-54283 causes request.form() size limits to be silently ignored for application/x-www-form-urlencoded bodies, enabling a memory-exhaustion DoS. The PDP is a JSON-only API: it never calls request.form(), does not depend on python-multipart, and parses no form-encoded or multipart request bodies, so the vulnerable form-parsing path is never executed. The fix lands only in starlette >= 1.3.1, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-54283 causes request.form() size limits to be silently ignored for application/x-www-form-urlencoded bodies, enabling a memory-exhaustion DoS. The PDP is a JSON-only API and never calls request.form(), so the vulnerable form-parsing path is never executed. Verified across horizon/, pdp-server/, and every installed package including opal-client and opal-common 0.9.6: the only request.form() call site in the whole stack is fastapi/routing.py:368, which is guarded by `if body_field:` / `if is_body_form:` and is dead because no PDP route declares a form body - every route takes a JSON/pydantic body or no body at all. Note that the absence of python-multipart is NOT what protects the PDP here: this CVE concerns the urlencoded parser, which starlette implements natively in starlette/requests.py with no python-multipart involvement. The load-bearing fact is that nothing calls request.form(). The fix lands only in starlette >= 1.3.1, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
     },
     {
       "vulnerability": {
@@ -43,7 +43,7 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
             { "@id": "pkg:pypi/starlette@0.50.0" }
           ]
@@ -51,7 +51,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-48710 lets a malformed HTTP Host header make request.url.path diverge from the path actually routed, so security checks that read request.url can be bypassed. The PDP performs no security decision on request.url: authentication is enforced per-route through FastAPI Depends security dependencies (HTTPBearer in horizon/authentication.py), not by path matching, and the app registers no add_middleware/BaseHTTPMiddleware and reads no raw ASGI scope paths. The one path-keyed authorization check - the write-route test in horizon/proxy/api.py cloud_proxy - reads request.path_params, which Starlette's router populates from the raw scope path and which this CVE explicitly leaves unaffected. The fix lands only in starlette >= 1.0.1, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-48710 lets a malformed HTTP Host header make request.url.path diverge from the path actually routed, so security checks that read request.url can be bypassed. The PDP performs no security decision on request.url. Authentication is enforced per-route through FastAPI Depends security dependencies (HTTPBearer in horizon/authentication.py, applied at horizon/pdp.py:489-525 and at router construction in horizon/local/api.py and horizon/facts/router.py), never by path matching. Note that the PDP does not build its own FastAPI app - it adopts OPAL's (horizon/pdp.py:280), which registers CORSMiddleware and a 500 exception handler via opal_client/client.py:272 -> opal_common/middleware.py:77,30. Those are the only APPLICATION-registered middleware and exception handler, and neither reads a path: starlette's CORSMiddleware inspects only scope['type'], scope['method'] and request headers, and OPAL's 500 handler reads only the origin and cookie headers. Three other layers exist and none changes the conclusion. FastAPI's framework defaults (ServerErrorMiddleware, ExceptionMiddleware, AsyncExitStackMiddleware and the three default exception handlers) read the exception, never a path. Starlette's AuthenticationMiddleware does read request.url (starlette/authentication.py:66,83), but nothing in the image imports starlette.authentication or installs it. And when PDP_ENABLE_MONITORING is enabled - which the control plane can do remotely, see the CVE-2026-50271 statement - ddtrace wraps FastAPI.build_middleware_stack with TraceMiddleware (ddtrace/contrib/internal/fastapi/patch.py:59,93), which does read scope['path'] and the Host header (ddtrace/contrib/internal/asgi/middleware.py:245-248); it builds its own string rather than a starlette URL and only tags a span with the result, so it makes no security decision. No code in horizon/, pdp-server/, opal-client or opal-common 0.9.6 reads a starlette request.url on an inbound request - every hit there belongs to an outbound HTTP client. The one path-keyed authorization check - the write-route test in horizon/proxy/api.py cloud_proxy - reads request.path_params, which starlette's router populates from the raw scope path and which this CVE explicitly leaves unaffected. The fix lands only in starlette >= 1.0.1, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
     },
     {
       "vulnerability": {
@@ -59,7 +59,7 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
             { "@id": "pkg:pypi/starlette@0.50.0" }
           ]
@@ -67,23 +67,23 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-48817 is an unsafe-reflection issue in starlette.endpoints.HTTPEndpoint request dispatch: the HTTP method is lowercased and resolved with getattr against the endpoint instance without restricting the lookup to known HTTP verbs, letting an attacker invoke internal helper methods that bypass authorization. The PDP defines no HTTPEndpoint or WebSocketEndpoint subclass anywhere in the codebase - every route is registered through FastAPI APIRouter decorators with explicit HTTP methods - so the vulnerable dispatch class is never instantiated or reached. The fix lands only in starlette >= 1.1.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-48817 is an unsafe-reflection issue in starlette.endpoints.HTTPEndpoint request dispatch: the HTTP method is lowercased and resolved with getattr against the endpoint instance without restricting the lookup to known HTTP verbs, letting an attacker invoke internal helper methods that bypass authorization. The PDP defines no HTTPEndpoint or WebSocketEndpoint subclass anywhere in the image - not in horizon/ or pdp-server/, and not in opal-client or opal-common 0.9.6, where the only occurrences are starlette's own endpoints module - so the vulnerable dispatch class is never instantiated. Every endpoint in the app is a plain async function, including the four FastAPI registers for itself via Starlette.add_route() rather than through an APIRouter decorator (/openapi.json, /docs, /docs/oauth2-redirect, /redoc). That distinction does not matter here, because starlette/routing.py:230-232 dispatches any function or method endpoint through request_response and only treats an endpoint as an ASGI class - the branch where HTTPEndpoint's getattr dispatch lives - when it is not a function. The fix lands only in starlette >= 1.1.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
     },
     {
       "vulnerability": {
-        "name": "CVE-2026-15308"
+        "name": "CVE-2026-54282"
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
-            { "@id": "pkg:generic/python" }
+            { "@id": "pkg:pypi/starlette@0.50.0" }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-15308 is a CPU denial-of-service in CPython's incremental HTML parser: html.parser.HTMLParser degrades to quadratic complexity on repeated unterminated markup declarations, so parsing attacker-controlled HTML can exhaust CPU. The PDP never parses HTML. Nothing imports html.parser - neither the PDP's own code (horizon/, pdp-server/) nor any package installed in the image; this was verified by scanning every .py file under site-packages, so the vulnerable class is never instantiated. Unlike the other CPython findings in this scan (CVE-2026-6019 and CVE-2026-7210, both cleared by moving the base image to Python 3.13.14), this one cannot be upgraded away: PSF fixed it only in 3.15.0b4 and NVD's CPE range is < 3.15.0, so no released Python satisfies it and every Python-based image in the world matches today. The Dockerfile intentionally floats the base image patch version (python:3.13-alpine3.23), so when 3.13.15 ships with the backport a rebuild will pick it up automatically. Remove this waiver at that point. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-54282 lets a request path that does not begin with '/' cross into the URL authority when request.url is reconstructed, so request.url.hostname and request.url.netloc become attacker-controlled. Exposure is limited to code that reads request.url before routing - notably middleware - or in 404/exception handlers, because the malformed path matches no route and no endpoint handler runs. Nothing constructs URL(scope=...) outside starlette itself, and no code in horizon/, pdp-server/, opal-client or opal-common 0.9.6 reads a starlette request.url on an inbound request - every hit there belongs to an outbound HTTP client. Two reads do exist elsewhere in the installed set and neither is reachable: starlette/authentication.py:66,83 reads request.url, but nothing imports starlette.authentication or installs AuthenticationMiddleware; and ddtrace's TraceMiddleware reads scope['path'] and the Host header (ddtrace/contrib/internal/asgi/middleware.py:245-248) when PDP_ENABLE_MONITORING is enabled, but it builds its own string rather than a starlette URL and only tags a span, making no security decision. Of starlette 0.50.0's own URL(scope=) call sites, StaticFiles is never mounted and neither TrustedHostMiddleware nor HTTPSRedirectMiddleware is registered - the only application-registered middleware is OPAL's CORSMiddleware (opal_common/middleware.py:77), which reads no URL, and its 500 handler reads only request headers. The one remaining pre-routing read, the redirect_slashes branch at starlette/routing.py:761, cannot fire for a path lacking a leading slash: it requires a route match, and starlette/routing.py:221 asserts that every registered route path starts with '/'. FastAPI's own docs handlers read scope['root_path'], which is server-configured rather than attacker-controlled. The fix lands only in starlette >= 1.3.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
     },
     {
       "vulnerability": {
@@ -91,7 +91,7 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "@id": "pkg:docker/permitio/pdp-v2",
           "subcomponents": [
             { "@id": "pkg:pypi/ddtrace@3.19.8" }
           ]
@@ -99,7 +99,7 @@
       ],
       "status": "not_affected",
       "justification": "inline_mitigations_already_exist",
-      "impact_statement": "CVE-2026-50271 is a remote DoS in ddtrace's W3C baggage propagator: the extract path does not enforce DD_TRACE_BAGGAGE_MAX_ITEMS or DD_TRACE_BAGGAGE_MAX_BYTES, so an unauthenticated caller can drive unbounded CPU and memory use with an oversized baggage header. The PDP ships an inline mitigation that removes the vulnerable parser from the request path: the image sets DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,tracecontext (see Dockerfile), dropping 'baggage' from ddtrace's default extract styles of 'datadog,tracecontext,baggage', so the unbounded baggage extractor is never invoked on inbound requests. Independently, ddtrace only reaches the inbound request path at all when PDP_ENABLE_MONITORING is true, which defaults to false (horizon/config.py); with the default configuration patch(fastapi=True) is never called and ddtrace instruments no incoming HTTP. Injection style is left at its default, so outbound baggage propagation is unchanged. The fix lands only in ddtrace >= 4.8.2, but opal-common 0.9.6 caps ddtrace<4, so the PDP is held at 3.x (see requirements.txt). This waiver and the Dockerfile mitigation are temporary and must both be removed once OPAL relaxes its ddtrace<4 bound and ddtrace is upgraded to >= 4.8.2. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-50271 is a remote DoS in ddtrace's W3C baggage propagator: the extract path does not enforce DD_TRACE_BAGGAGE_MAX_ITEMS or DD_TRACE_BAGGAGE_MAX_BYTES, so an unauthenticated caller can drive unbounded CPU and memory use with an oversized baggage header. The PDP ships an inline mitigation that removes the vulnerable parser from the request path: the image sets DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,tracecontext (see Dockerfile), dropping 'baggage' from ddtrace's default extract styles of 'datadog,tracecontext,baggage', so the unbounded baggage extractor is never invoked on inbound requests. In ddtrace 3.19.8 that list is a full replacement rather than an append, and the baggage extractor is called only when 'baggage' is present in it, so removing the style genuinely bypasses the vulnerable code. This ENV is the load-bearing mitigation and holds on its own, whether or not monitoring is enabled. A second condition narrows exposure further but must not be relied on alone: ddtrace reaches the inbound request path only when PDP_ENABLE_MONITORING is true, which defaults to false (horizon/config.py:114) and gates patch(fastapi=True) at horizon/pdp.py:262-263 - but that flag is not an invariant, because horizon/pdp.py:239 applies the control plane's remote config override before the check, so monitoring can be switched on remotely without a redeploy. Operators can likewise override the ENV itself via `docker run -e` or a Helm pdpEnvs entry; doing so re-exposes this CVE and should not be done while the PDP is pinned to ddtrace 3.x. Injection style is left at its default, so outbound baggage propagation is unchanged. The fix lands only in ddtrace >= 4.8.2, but opal-common 0.9.6 caps ddtrace<4, so the PDP is held at 3.x (see requirements.txt). This waiver and the Dockerfile mitigation are temporary and must both be removed once OPAL relaxes its ddtrace<4 bound and ddtrace is upgraded to >= 4.8.2. Tracked under PER-15358."
     }
   ]
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,27 @@ jobs:
   docker-scout:
     runs-on: ubuntu-latest
     needs: build-pdp-image
-    if: github.event_name == 'pull_request'
+    # Deliberately unconditional. This job used to carry
+    # `if: github.event_name == 'pull_request'`, which meant the CVE gate ran on
+    # pull requests only - never on the artifact customers actually pull.
+    # release.yml calls this workflow with `uses:`, and inside a called workflow
+    # github.event_name is the CALLER'S event ("release"), so the condition was
+    # false on every release and the job was skipped. Verified on release
+    # v0.9.14 (run 30900950607): `pdp-tests / docker-scout  skipped`, while
+    # build-and-push-pdp went on to push :0.9.14 and :latest ungated. Pushes to
+    # main were skipped for the same reason.
+    #
+    # Adding 'workflow_call' to the condition would NOT have fixed it - that is
+    # not a value github.event_name ever takes. The trigger set in `on:` above
+    # is already exactly the set we want scanned, so the correct fix is to have
+    # no condition at all.
+    #
+    # This makes the gate release-blocking: release.yml has
+    # build-and-push-pdp: needs: pdp-tests, so a new HIGH published between
+    # merge and release cut now stops the Docker Hub push and the ECS redeploy.
+    # That is the intent (PER-15532: a customer scan of 0.9.14-rc1 found CVEs CI
+    # never flagged). Recovery is to fix the dependency or add a VEX statement
+    # and re-cut the release.
     permissions:
       # required to upload the SARIF report
       security-events: write
@@ -209,6 +229,11 @@ jobs:
           exit-code: false
           sarif-file: scout-results.sarif
           summary: true
+          # scout-action defaults write-comment to true. Now that this job also
+          # runs on release and push events, where there is no PR to comment on,
+          # gate it explicitly rather than relying on the action to work that
+          # out for itself.
+          write-comment: ${{ github.event_name == 'pull_request' }}
 
       - name: Docker Scout CVE gate (high and critical)
         uses: docker/scout-action@v1
@@ -217,20 +242,30 @@ jobs:
           image: local://permitio/pdp-v2:next
           only-severities: critical,high
           exit-code: true
+          # Only critical/high block. Medium and low are reported by the step
+          # above and surfaced through the SARIF upload, but are non-blocking by
+          # policy - they are triaged rather than gated. Live example: busybox
+          # CVE-2025-60876, a medium with no upstream fix available.
+          #
           # Accept CVEs marked not_affected in the OpenVEX doc (see
           # .docker/scout/pdp-v2.vex.json) so the gate does not fail on
           # vulnerabilities whose code path the PDP never executes and for which
           # no usable fix is available: starlette CVE-2026-48710 / CVE-2026-48817 /
           # CVE-2026-48818 / CVE-2026-54283, all fixed only in starlette >=1.x, which
-          # OPAL's starlette<1 cap forbids; ddtrace CVE-2026-50271, fixed only in
-          # ddtrace >=4.8.2, which OPAL's ddtrace<4 cap forbids and which the Dockerfile
-          # mitigates by dropping "baggage" from the extract styles; and CPython
-          # CVE-2026-15308 (html.parser DoS), which nothing in the image imports and which
-          # is fixed only in 3.15.0b4, so no released Python clears it yet. See PER-15358.
+          # OPAL's starlette<1 cap forbids; and ddtrace CVE-2026-50271, fixed only in
+          # ddtrace >=4.8.2, which OPAL's ddtrace<4 cap forbids and which the
+          # Dockerfile mitigates by dropping "baggage" from the extract styles.
+          # (The VEX doc also carries CVE-2026-54282, but that one is low severity
+          # and could never trip this gate - it is waived so the report step and any
+          # future severity re-rating stay accurate.) See PER-15358.
           #
           # NOTE: this gate reads packages, so it does not flag the CPython interpreter
           # itself the way a CPE-based scanner does - that blind spot is why four Python
           # CVEs reached a customer scan of 0.9.14-rc1 without failing CI (PER-15532).
+          #
+          # NOTE: the scanned image is the single-arch linux/amd64 build produced by
+          # build-pdp-image. The multi-arch artifact that release.yml publishes is not
+          # what is scanned here, so linux/arm64 is not covered by this gate.
           vex-location: .docker/scout
           only-vex-affected: true
           # REQUIRED: docker scout only *applies* VEX statements whose author
@@ -239,12 +274,29 @@ jobs:
           # ("VEX: not affected") but NOT suppressed, so the gate still fails on
           # the waived CVEs. Must match the `author` field in pdp-v2.vex.json.
           vex-author: Permit.io
+          # No PR to comment on for release/push events - see the report step.
+          write-comment: ${{ github.event_name == 'pull_request' }}
 
       - name: Upload SARIF report
-        if: always()
+        # The file guard suppresses a second, misleading error when an earlier
+        # step already failed the job and never produced the SARIF.
+        if: always() && hashFiles('scout-results.sarif') != ''
+        # This step is reporting, not gating - the gate is the step above. Now
+        # that this job blocks releases, do not let a code-scanning upload
+        # problem (processing error, API 5xx, size limit; upload-sarif defaults
+        # wait-for-processing: true) fail pdp-tests and with it the Docker Hub
+        # push and the ECS redeploy. A failed upload costs visibility, not
+        # safety.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: scout-results.sarif
+          # codeql-action keys an analysis by `${workflowPath}:${jobName}`, and
+          # resolves workflowPath from the run's own workflow. A release-triggered
+          # run would therefore key as release.yml:docker-scout while PR and push
+          # runs key as tests.yml:docker-scout, splitting the same job's results
+          # across two analyses. Pin the category so all three agree.
+          category: docker-scout
 
   rust-ci:
     name: Rust CI

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,14 +104,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 #                                                             < 3.11.4, so 3.13 is out of it
 # PSF fixed these only on the 3.13/3.14/3.15 branches - there is no 3.10/3.11/3.12 backport -
 # so the vulnerable code really was present in 3.10.20 and an upgrade was the only fix.
-# CVE-2026-15308 (html.parser DoS) is NOT cleared by this bump: it is patched only in
-# 3.15.0b4 and NVD's range is < 3.15.0, so no released Python satisfies it. It is waived in
-# .docker/scout/pdp-v2.vex.json as unreachable (nothing in the image imports html.parser).
+# CVE-2026-15308 (html.parser DoS) was waived here as unreachable when this base was
+# python:3.13.14. That waiver has since been removed: the tag now resolves to 3.13.15 and
+# Scout no longer reports the CVE at any severity, which is exactly the outcome the
+# floating patch version was chosen to produce (the rebuild-picks-it-up posture in
+# PER-15532). Nothing to carry forward.
 #
-# The patch version floats deliberately (see the previous python:3.10-alpine3.22 base and
-# the rebuild-picks-it-up posture in PER-15532): when 3.13.15 ships it will clear
-# CVE-2026-15308 automatically and that waiver can then be dropped. Do not drop below
-# 3.13.14 - that is the floor for the fixes above.
+# Keep floating the patch version, and do not drop below 3.13.14 - that is still the floor
+# for the CVE-2026-6019 and CVE-2026-7210 fixes above.
 #
 # Python 3.10 also reaches end of life in October 2026, so this move was due regardless.
 FROM python:3.13-alpine3.23 AS main
@@ -210,10 +210,14 @@ ENV OPAL_INLINE_OPA_LOG_FORMAT="http"
 # header. The fix is only in ddtrace >= 4.8.2, which opal-common's `ddtrace<4,>=3.0.0`
 # cap forbids, so we remove the vulnerable parser from the request path instead.
 #
-# This only matters when PDP_ENABLE_MONITORING=true (default false) - that is what calls
-# patch(fastapi=True) and puts ddtrace on the inbound request path at all. Injection is
-# left at its default, so outbound baggage propagation is unaffected. Remove this once
-# OPAL relaxes its ddtrace<4 bound and ddtrace moves to >= 4.8.2. See PER-15358.
+# This ENV is the load-bearing mitigation and holds on its own. ddtrace only reaches the
+# inbound request path when PDP_ENABLE_MONITORING=true, which defaults to false - but do
+# NOT treat that flag as a second line of defence: horizon/pdp.py:239 applies the control
+# plane's remote config override BEFORE the check at :262, so monitoring can be switched
+# on remotely without a redeploy. Do not override this ENV (docker run -e, Helm pdpEnvs)
+# while the PDP is pinned to ddtrace 3.x - doing so re-exposes the CVE. Injection is left
+# at its default, so outbound baggage propagation is unaffected. Remove this once OPAL
+# relaxes its ddtrace<4 bound and ddtrace moves to >= 4.8.2. See PER-15358.
 ENV DD_TRACE_PROPAGATION_STYLE_EXTRACT="datadog,tracecontext"
 
 # horizon configuration -----------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,16 +54,17 @@ protobuf>=6.33.5 # pinned to avoid CVE-2026-0994
 # the alpine build stays prebuilt and needs no Rust toolchain.
 cryptography>=50.0.0,<51
 # starlette is capped <1 by opal-common/opal-client 0.9.6 (and further to <0.51.0 via
-# fastapi-utils -> fastapi 0.125.0). Four starlette CVEs (CVE-2026-54283 fixed in 1.3.1,
+# fastapi-utils -> fastapi 0.125.0). Five starlette CVEs (CVE-2026-54283 fixed in 1.3.1,
 # CVE-2026-48817 fixed in 1.1.0, CVE-2026-48818 fixed in 1.1.0, CVE-2026-48710 fixed in
-# 1.0.1) have no <1 backport, so they cannot be upgraded away while OPAL caps
-# starlette<1. All four are waived in .docker/scout/pdp-v2.vex.json as not_affected
-# (unreachable code paths: JSON-only API with no request.form(); Linux with no
-# StaticFiles; no HTTPEndpoint subclasses; no security decision reads request.url).
+# 1.0.1, CVE-2026-54282 fixed in 1.3.0) have no <1 backport, so they cannot be upgraded
+# away while OPAL caps starlette<1. All five are waived in
+# .docker/scout/pdp-v2.vex.json as not_affected (unreachable code paths: JSON-only API
+# with no request.form(); Linux with no StaticFiles; no HTTPEndpoint subclasses; no
+# security decision reads request.url; and nothing reads request.url.hostname).
 # Pinned exactly so the waiver PURLs stay bound (the image build has no lockfile, so an
 # unpinned starlette could drift to a new 0.x and silently break the match). Remove this
-# pin + all four waivers and upgrade starlette>=1.3.1 once OPAL relaxes its starlette<1
-# bound. See PER-15358.
+# pin + all five waivers and upgrade starlette>=1.3.1 once OPAL relaxes its starlette<1
+# bound - that target already covers all five. See PER-15358.
 starlette==0.50.0
 # websockets is pinned exactly because nothing else bounds it: opal-common/opal-client and
 # fastapi-websocket-rpc allow >=10.3, fastapi-websocket-pubsub >=14.0, uvicorn[standard]


### PR DESCRIPTION
fix(ci): scan release builds, unpin VEX from :next, correct waivers (PER-15358)

## The gate never ran on what we ship

docker-scout carried `if: github.event_name == 'pull_request'`. release.yml
calls tests.yml with `uses:`, and inside a called workflow
github.event_name is the CALLER'S event - "release" - so the condition was
false and the job was skipped on every release, and on every push to main.

Not a reading of the YAML. Release v0.9.14, run 30900950607:

    success   pdp-tests / build-pdp-image
    success   pdp-tests / pdp-tester
    skipped   pdp-tests / docker-scout      <-- the gate
    success   build-and-push-pdp            # pushed :0.9.14 and :latest

Every image on Docker Hub was built and pushed without passing a CVE gate.
Scanning ran only on PRs, against a :next tag that is never published.

Adding 'workflow_call' to the condition would not have helped - that is not
a value github.event_name takes. `on:` already enumerates exactly the
trigger set we want scanned, so the condition is removed outright.

This makes the gate release-blocking (build-and-push-pdp needs pdp-tests).
That is the intent - PER-15532 was a customer scan of 0.9.14-rc1 finding
CVEs CI never flagged - but it is a real change in failure mode: a HIGH
published between merge and release cut now stops the push and the ECS
redeploy until the dependency is fixed or a VEX statement is added.

Two limits stated plainly rather than oversold: releases run the workflow
AT THE TAG, so a release cut from a commit predating a VEX correction uses
that commit's waiver set; and the scanned image is the single-arch
linux/amd64 CI build, so linux/arm64 is still covered by nothing.

Note docker-scout is NOT currently in the repo's required status checks, so
a new HIGH still reaches main freely and first bites at the release cut.
Adding it there is a follow-up worth doing.

## VEX: unpin from the :next tag

All statements used `pkg:docker/permitio/pdp-v2@next`. That matches today
only because the scanned tag is hardcoded :next - the day anyone
parameterises it, all six waivers silently stop matching and the
now-blocking gate hard-fails on already-triaged CVEs. Dropping the version
qualifier is a strict superset: openvex PurlMatches rejects only when both
versions are non-empty and unequal, so an empty version matches any tag.
Confirmed against go-vex v0.2.7, the version Scout links.

Subcomponent PURLs stay exact-versioned on purpose - pkg:pypi/starlette@0.50.0
must not match 0.51.0. That is how a waiver expires when the pin moves.

## Waiver corrections

- CVE-2026-48710 contained a false claim: "the app registers no
  add_middleware/BaseHTTPMiddleware". The PDP adopts OPAL's app
  (horizon/pdp.py:280), which registers CORSMiddleware and a 500 handler
  (opal_common/middleware.py:77,30). `grep -rn add_middleware horizon/`
  returns nothing, which is how the claim got written. The conclusion
  survives - CORSMiddleware reads no path - but that is the argument the
  waiver needed to make and did not. The rewrite also names the three
  layers a "no middleware" claim would miss: FastAPI's framework defaults,
  starlette's AuthenticationMiddleware (not installed), and ddtrace's
  TraceMiddleware, which DOES read scope['path'] and the Host header
  (ddtrace/contrib/internal/asgi/middleware.py:245-248) whenever monitoring
  is on - it tags a span rather than making a security decision.
- CVE-2026-54282 (LOW 3.7) was unwaived. Added, with the same carve-outs
  rather than a blanket "nothing in the image reads request.url" - which
  would have been false, see starlette/authentication.py:66,83.
- CVE-2026-15308 removed entirely: the base image now resolves to CPython
  3.13.15 and Scout no longer reports it at any severity, so `not_affected`
  would now be the wrong status. This was also the only version-less
  subcomponent (pkg:generic/python), which would have suppressed the
  finding across every future interpreter. Stale Dockerfile comment
  dropped with it.
- CVE-2026-50271: dropped "Independently". horizon/pdp.py:239 applies the
  control plane's remote config before the ENABLE_MONITORING check at :262,
  so monitoring can be enabled remotely - the ENV is the load-bearing
  mitigation, not the flag. Dockerfile comment aligned to match.
- CVE-2026-54283: removed the python-multipart clause. True but irrelevant;
  this CVE is the urlencoded path, which starlette parses natively.
- CVE-2026-48817: removed "every route is registered through APIRouter
  decorators" - FastAPI registers /docs and /openapi.json via add_route().

## Hardening that the trigger change makes necessary

- write-comment gated on pull_request for both scout steps. The input
  exists and defaults to true (docker/scout-action action.yaml:197), and
  there is no PR to comment on during a release.
- SARIF upload requires the file to exist, and is now continue-on-error:
  the gate is the step above it, and a code-scanning upload problem must
  not block a customer release for zero security signal.
- category: docker-scout. codeql-action keys analyses by
  `${workflowPath}:${jobName}` resolved from the run's own workflow, so a
  release-triggered run would otherwise key separately from PR/push runs.
- Documented that medium/low are report-only by policy.

## Also

requirements.txt's starlette block said "four CVEs / all four are waived";
it is five now that CVE-2026-54282 is tracked. Left as a correct removal
checklist for when OPAL relaxes its starlette<1 cap.

## Merge order

Must land AFTER permitio/permit-opa#48 and permitio/PDP#334 (the golang:1.26 builder).
This arms a release-blocking gate; today that gate reports 4 HIGH from the
OPA binary. Merging this first would block the next release.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>



---

## Merge order (3 PRs, PER-15358)

1. **permitio/PDP#334** — golang:1.26 builder.
2. **permitio/permit-opa#48** — the CVE fixes. Takes the gate from 4 HIGH to 0.
3. **permitio/PDP#335 — this PR.** Merge last.

### Reviewer note

The versionless-PURL argument was verified against `openvex/go-vex` v0.2.7 (the library Scout links), not against Scout’s closed-source matcher. It is self-mitigating — if the match broke, this PR’s own `docker-scout` run would go red on the five starlette/ddtrace waivers rather than reporting only the OPA findings. Worth glancing at that run rather than taking the argument on faith.
