### PR TITLE
ci: exclude the pdp-tester policy.* cases from this job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,13 @@ jobs:
           # around so the post-mortem step below can read their logs.
           START_TIMEOUT: "180"
           AUTO_REMOVE: "false"
+          # pdp-tester's policy.* cases write policy SCHEMA -- roles, resource
+          # types and relations on the stock File/Folder types -- into the shared
+          # staging environment on every run, rather than only facts. This job
+          # checks pdp-tester out at main with no pinned ref and otherwise runs
+          # every case it discovers, so without this it would opt into that churn
+          # silently the moment those cases landed. See permitio/pdp-tester#152.
+          EXCLUDE_TESTS: '["policy.*"]'
         run: |
           set -o pipefail
           # The default GitHub Actions shell runs with `-e`, so capture the


### PR DESCRIPTION
One line: excludes the new pdp-tester `policy.*` cases from this repo's `pdp-tester` job. Companion to [permitio/pdp-tester#152](https://github.com/permitio/pdp-tester/pull/152) ([PER-15775](https://linear.app/permit/issue/PER-15775/pdp-tester-add-policy-plane-cases-role-permission-resource-type)).

## Why this repo needs a change at all

`.github/workflows/tests.yml` checks out `permitio/pdp-tester` **with no pinned `ref:`**, so it tracks that repo's `main`, and then runs:

```
python -m pdp_tester --docker --local --tag next --skip-generate
```

with no include or exclude list — which means it runs **every test case it discovers**. So a new case added in pdp-tester lands here automatically, on the next run, without anything in this repo changing.

## What is landing there

pdp-tester#152 adds five `policy.*` cases. Unlike every existing case, they create policy **schema** during the test — roles, resource types, and relations on the stock `File`/`Folder` types — and only then the facts that depend on it. That is the point: facts ride the WAL while schema and rego ride `POLICY_DATA`/`POLICY_FILES`, so a PDP with a stale policy plane answers the existing suite correctly and stays green.

For this job it would mean schema writes into the shared staging Permit environment on every run, each triggering a rego rebuild pushed to every PDP in that environment — on top of roughly +50s of runtime from the propagation waits those cases need. Nothing here needs that coverage: the cases are meant for the pdp-tester and Cloud PDP releases, which name them explicitly.

## Merge order

No constraint. This is safe to merge before or after pdp-tester#152 — `EXCLUDE_TESTS` is a pattern, so it costs nothing while the cases do not exist, and is already in place if they land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
