### PR TITLE
fix: clear all 12 CVEs from customer scan of published pdp-v2:0.9.14 (PER-15358)

### DIFF
--- a/.docker/scout/pdp-v2.vex.json
+++ b/.docker/scout/pdp-v2.vex.json
@@ -3,7 +3,7 @@
   "@id": "https://openvex.dev/docs/permitio-pdp/pdp-v2-cve-waivers",
   "author": "Permit.io",
   "timestamp": "2026-09-11T12:00:00Z",
-  "version": 6,
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -13,13 +13,14 @@
         {
           "@id": "pkg:docker/permitio/pdp-v2@next",
           "subcomponents": [
-            { "@id": "pkg:golang/golang.org/x/crypto@v0.55.0" }
+            { "@id": "pkg:golang/golang.org/x/crypto@0.53.0" },
+            { "@id": "pkg:golang/golang.org/x/crypto@0.55.0" }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-78662 is a connection-deadlock DoS - a channel registered in the mux's chanList before it is established lets a malicious peer flood incomingRequests in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-78662 is a connection-deadlock DoS - a channel registered in the mux's chanList before it is established lets a malicious peer flood incomingRequests in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Two subcomponent PURLs are listed on purpose: 0.53.0 is what the build resolves until permit-opa#49 merges and 0.55.0 is what it resolves after, and docker scout matches VEX subcomponents on the FULL PURL string, so a statement naming only one of them silently stops suppressing the moment the version moves. Note also that scout emits Go PURLs WITHOUT the conventional `v` prefix (pkg:golang/golang.org/x/crypto@0.53.0, not @v0.53.0) - the first version of this waiver used @v0.55.0 and bound to nothing at all. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
     },
     {
       "vulnerability": {
@@ -29,13 +30,14 @@
         {
           "@id": "pkg:docker/permitio/pdp-v2@next",
           "subcomponents": [
-            { "@id": "pkg:golang/golang.org/x/crypto@v0.55.0" }
+            { "@id": "pkg:golang/golang.org/x/crypto@0.53.0" },
+            { "@id": "pkg:golang/golang.org/x/crypto@0.55.0" }
           ]
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-56855 is a connection-deadlock DoS - crafted post-establishment channel messages are buffered instead of being treated as a protocol error in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
+      "impact_statement": "CVE-2026-56855 is a connection-deadlock DoS - crafted post-establishment channel messages are buffered instead of being treated as a protocol error in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Two subcomponent PURLs are listed on purpose: 0.53.0 is what the build resolves until permit-opa#49 merges and 0.55.0 is what it resolves after, and docker scout matches VEX subcomponents on the FULL PURL string, so a statement naming only one of them silently stops suppressing the moment the version moves. Note also that scout emits Go PURLs WITHOUT the conventional `v` prefix (pkg:golang/golang.org/x/crypto@0.53.0, not @v0.53.0) - the first version of this waiver used @v0.55.0 and bound to nothing at all. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
     },
     {
       "vulnerability": {

--- a/.docker/scout/pdp-v2.vex.json
+++ b/.docker/scout/pdp-v2.vex.json
@@ -2,8 +2,8 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/permitio-pdp/pdp-v2-cve-waivers",
   "author": "Permit.io",
-  "timestamp": "2026-07-29T00:00:00Z",
-  "version": 4,
+  "timestamp": "2026-09-11T00:00:00Z",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -68,22 +68,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "CVE-2026-48817 is an unsafe-reflection issue in starlette.endpoints.HTTPEndpoint request dispatch: the HTTP method is lowercased and resolved with getattr against the endpoint instance without restricting the lookup to known HTTP verbs, letting an attacker invoke internal helper methods that bypass authorization. The PDP defines no HTTPEndpoint or WebSocketEndpoint subclass anywhere in the codebase - every route is registered through FastAPI APIRouter decorators with explicit HTTP methods - so the vulnerable dispatch class is never instantiated or reached. The fix lands only in starlette >= 1.1.0, but opal-common/opal-client 0.9.6 cap starlette<1, so the PDP is pinned to 0.50.0 (see requirements.txt). This waiver is temporary and must be removed once OPAL relaxes its starlette<1 bound and starlette is upgraded to >= 1.3.1. Tracked under PER-15358."
-    },
-    {
-      "vulnerability": {
-        "name": "CVE-2026-15308"
-      },
-      "products": [
-        {
-          "@id": "pkg:docker/permitio/pdp-v2@next",
-          "subcomponents": [
-            { "@id": "pkg:generic/python" }
-          ]
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-15308 is a CPU denial-of-service in CPython's incremental HTML parser: html.parser.HTMLParser degrades to quadratic complexity on repeated unterminated markup declarations, so parsing attacker-controlled HTML can exhaust CPU. The PDP never parses HTML. Nothing imports html.parser - neither the PDP's own code (horizon/, pdp-server/) nor any package installed in the image; this was verified by scanning every .py file under site-packages, so the vulnerable class is never instantiated. Unlike the other CPython findings in this scan (CVE-2026-6019 and CVE-2026-7210, both cleared by moving the base image to Python 3.13.14), this one cannot be upgraded away: PSF fixed it only in 3.15.0b4 and NVD's CPE range is < 3.15.0, so no released Python satisfies it and every Python-based image in the world matches today. The Dockerfile intentionally floats the base image patch version (python:3.13-alpine3.23), so when 3.13.15 ships with the backport a rebuild will pick it up automatically. Remove this waiver at that point. Tracked under PER-15358."
     },
     {
       "vulnerability": {

--- a/.docker/scout/pdp-v2.vex.json
+++ b/.docker/scout/pdp-v2.vex.json
@@ -2,9 +2,41 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/permitio-pdp/pdp-v2-cve-waivers",
   "author": "Permit.io",
-  "timestamp": "2026-09-11T00:00:00Z",
-  "version": 5,
+  "timestamp": "2026-09-11T12:00:00Z",
+  "version": 6,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-78662"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "subcomponents": [
+            { "@id": "pkg:golang/golang.org/x/crypto@v0.55.0" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-78662 is a connection-deadlock DoS - a channel registered in the mux's chanList before it is established lets a malicious peer flood incomingRequests in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56855"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/permitio/pdp-v2@next",
+          "subcomponents": [
+            { "@id": "pkg:golang/golang.org/x/crypto@v0.55.0" }
+          ]
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-56855 is a connection-deadlock DoS - crafted post-establishment channel messages are buffered instead of being treated as a protocol error in golang.org/x/crypto/ssh. It reaches the pdp-v2 image only because /app/bin/opa is compiled from permitio/permit-opa, which carries x/crypto as an INDIRECT dependency. The vulnerable package is not present in the binary: `go list -deps ./cmd/opa` in permit-opa resolves exactly these x/crypto packages - cryptobyte(+asn1), chacha20, chacha20poly1305, internal/poly1305, internal/alias, pbkdf2, curve25519, blake2b, salsa20/salsa, nacl/box, nacl/secretbox, hkdf, sha3 - and golang.org/x/crypto/ssh is absent from that list, so the SSH transport code is never linked, let alone reachable. The PDP additionally speaks no SSH on any code path of its own. Both CVEs are fixed only in x/crypto >= 0.56.0, which declares `go >= 1.26.0`; Go 1.26 is not released (no golang:1.26 base image exists) and this image builds on golang:1.25-bookworm, so the upgrade is not available yet. permitio/permit-opa#49 raises the floor as far as Go 1.25 allows (0.55.0, which clears CVE-2026-56854) and bumps grpc to 1.83.2. Remove this waiver and move x/crypto to >= 0.56.0 once a Go 1.26 toolchain is available. Tracked under PER-15358."
+    },
     {
       "vulnerability": {
         "name": "CVE-2026-48818"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,14 @@ jobs:
         tags: permitio/pdp-v2:${{ github.event.release.tag_name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        # Never serve the OS/dependency layers from the GHA cache. Their cache key is the
+        # instruction text plus the parent layer, so a release cut weeks after the last
+        # build replays the OLD `apk update && apk upgrade` + `pip install` results and
+        # re-ships packages that upstream has since patched. That is exactly how
+        # permitio/pdp-v2:0.9.14 came to carry openssl 3.5.7-r0 into a customer scan five
+        # weeks after Alpine shipped 3.5.8-r0 (PER-15358). The expensive Rust stages
+        # (rust_chef/rust_planner/rust_builder) still cache normally.
+        no-cache-filter: main,opa_build
 
     - name: Build and push PDP image - (official release)
       if: "!github.event.release.prerelease"
@@ -74,6 +82,9 @@ jobs:
         tags: permitio/pdp-v2:${{ github.event.release.tag_name }},permitio/pdp-v2:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        # See the pre-release step above: forces `apk upgrade` and `pip install` to
+        # re-resolve so a release can never republish a stale OS/dependency set.
+        no-cache-filter: main,opa_build
 
   update-pdp-api-ecs-service:
     needs: build-and-push-pdp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,28 @@ jobs:
         tags: permitio/pdp-v2:${{ github.event.release.tag_name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        # Never serve the OS/dependency layers from the GHA cache. Their cache key is the
-        # instruction text plus the parent layer, so a release cut weeks after the last
-        # build replays the OLD `apk update && apk upgrade` + `pip install` results and
-        # re-ships packages that upstream has since patched. That is exactly how
-        # permitio/pdp-v2:0.9.14 came to carry openssl 3.5.7-r0 into a customer scan five
-        # weeks after Alpine shipped 3.5.8-r0 (PER-15358). The expensive Rust stages
-        # (rust_chef/rust_planner/rust_builder) still cache normally.
-        no-cache-filter: main,opa_build
+        # Never serve the `main` stage from the GHA cache. Its cache key is the instruction
+        # text plus the parent layer, so when the base image digest has NOT moved but
+        # Alpine's package index has, a release cut later replays the old
+        # `apk update && apk upgrade` + `pip install` results and re-ships packages
+        # upstream has since patched. That is the shape of PER-15358: 0.9.14 froze
+        # libcrypto3 3.5.7-r0 on 2026-08-04 and Alpine published 3.5.8-r0 afterwards.
+        #
+        # NOTE the input is PLURAL. `no-cache-filter` (singular) is the buildx CLI flag;
+        # the action input is `no-cache-filters`, and an undeclared input is warned about
+        # and dropped - i.e. the singular spelling makes this silently inert.
+        #
+        # `opa_build` is deliberately NOT listed: `COPY custom* /custom` pulls in
+        # custom_opa.tar.gz, which the Pre-build step regenerates every run, so that stage
+        # already re-executes unconditionally. Listing it would imply this filter controls
+        # the OPA binary's Go dependency versions, and it does not - those come from
+        # permit-opa's go.sum (see permitio/permit-opa#49).
+        #
+        # The Rust stages are untouched by this filter, which is not the same as saying
+        # they cache cleanly: `rust_planner`'s `COPY . .` also sees the regenerated
+        # tarball, so it and the final `cargo zigbuild` re-run every build regardless.
+        # What does still cache is `cargo chef cook`, keyed on recipe.json.
+        no-cache-filters: main
 
     - name: Build and push PDP image - (official release)
       if: "!github.event.release.prerelease"
@@ -84,7 +98,8 @@ jobs:
         cache-to: type=gha,mode=max
         # See the pre-release step above: forces `apk upgrade` and `pip install` to
         # re-resolve so a release can never republish a stale OS/dependency set.
-        no-cache-filter: main,opa_build
+        # Plural input, and `main` only - both for the reasons documented there.
+        no-cache-filters: main
 
   update-pdp-api-ecs-service:
     needs: build-and-push-pdp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,9 +231,7 @@ jobs:
           # CVE-2026-48818 / CVE-2026-54283, all fixed only in starlette >=1.x, which
           # OPAL's starlette<1 cap forbids; ddtrace CVE-2026-50271, fixed only in
           # ddtrace >=4.8.2, which OPAL's ddtrace<4 cap forbids and which the Dockerfile
-          # mitigates by dropping "baggage" from the extract styles; and CPython
-          # CVE-2026-15308 (html.parser DoS), which nothing in the image imports and which
-          # is fixed only in 3.15.0b4, so no released Python clears it yet. See PER-15358.
+          # mitigates by dropping "baggage" from the extract styles. See PER-15358.
           #
           # NOTE: this gate reads packages, so it does not flag the CPython interpreter
           # itself the way a CPE-based scanner does - that blind spot is why four Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,7 +231,11 @@ jobs:
           # CVE-2026-48818 / CVE-2026-54283, all fixed only in starlette >=1.x, which
           # OPAL's starlette<1 cap forbids; ddtrace CVE-2026-50271, fixed only in
           # ddtrace >=4.8.2, which OPAL's ddtrace<4 cap forbids and which the Dockerfile
-          # mitigates by dropping "baggage" from the extract styles. See PER-15358.
+          # mitigates by dropping "baggage" from the extract styles; and x/crypto
+          # CVE-2026-78662 / CVE-2026-56855, which live in golang.org/x/crypto/ssh - a
+          # package `go list -deps ./cmd/opa` proves is not linked into /app/bin/opa - and
+          # which are fixed only in x/crypto >=0.56.0, a version that declares
+          # `go >= 1.26.0` while Go 1.26 is still unreleased. See PER-15358.
           #
           # NOTE: this gate reads packages, so it does not flag the CPython interpreter
           # itself the way a CPE-based scanner does - that blind spot is why four Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,18 @@ jobs:
           tags: permitio/pdp-v2:next
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Must match release.yml. Without it the image that pdp-tester exercises and
+          # that docker-scout/Trivy gate is built from a possibly-stale cached `main`
+          # stage, while the released image re-resolves `apk upgrade` and `pip install`
+          # - so CI would be validating and scanning a DIFFERENT package set than the one
+          # customers pull. Two ways that bites: a gate that passes on cached packages
+          # while the release ships newer ones, and the reverse, a gate that fails on
+          # packages the release would not actually contain.
+          #
+          # Plural input on purpose - `no-cache-filter` is the buildx CLI flag, the action
+          # input is `no-cache-filters`, and an undeclared input is silently dropped.
+          # See PER-15358 and the long note in release.yml.
+          no-cache-filters: main
 
       - name: Save Docker image as artifact
         run: docker save permitio/pdp-v2:next -o pdp-image.tar
@@ -247,6 +259,15 @@ jobs:
           # this, our Permit.io-authored statements are matched and displayed
           # ("VEX: not affected") but NOT suppressed, so the gate still fails on
           # the waived CVEs. Must match the `author` field in pdp-v2.vex.json.
+          #
+          # SCOPE OF THE VEX DOC: every statement in pdp-v2.vex.json binds its product to
+          # `pkg:docker/permitio/pdp-v2@next`, which matches the `local://...:next` image
+          # scanned here and nothing else. That is correct precisely BECAUSE this gate is
+          # the only consumer of the OpenVEX doc - the scheduled re-scan of the published
+          # tags uses Trivy, which reads .trivyignore.yaml and keys on CVE id, so tag
+          # names never enter into it. If Scout is ever pointed at `:latest` or a release
+          # tag, every product @id here has to be extended first or all seven waivers
+          # stop suppressing and the run goes red on known non-issues.
           vex-author: Permit.io
 
       - name: Upload SARIF report

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # CVE-2026-15308 (html.parser CPU-exhaustion DoS) is now cleared too: it was waived here as
 # unreachable while it was patched only in 3.15.0b4, but CPython backported the fix and it
 # landed in 3.13.15 (also 3.14.7). The base tag floats, so the current build resolves
-# 3.13.15 and the waiver has been REMOVED from .docker/scout/pdp-v2.vex.json (v4 -> v5).
+# 3.13.15 and the waiver has been REMOVED from .docker/scout/pdp-v2.vex.json.
 # Do not drop below 3.13.15 - that is the floor for every fix named above. Note what
 # enforces that floor now, because it is not this comment: removing the waiver IS the
 # enforcement. While CVE-2026-15308 was waived, a base that resolved below 3.13.15 still

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # unreachable while it was patched only in 3.15.0b4, but CPython backported the fix and it
 # landed in 3.13.15 (also 3.14.7). The base tag floats, so the current build resolves
 # 3.13.15 and the waiver has been REMOVED from .docker/scout/pdp-v2.vex.json (v4 -> v5).
-# Do not drop below 3.13.15 - that is the floor for every fix named above.
+# Do not drop below 3.13.15 - that is the floor for every fix named above. Note what
+# enforces that floor now, because it is not this comment: removing the waiver IS the
+# enforcement. While CVE-2026-15308 was waived, a base that resolved below 3.13.15 still
+# sailed through the gate. With the waiver gone, the same regression is reported by Scout
+# with nothing to suppress it, so it FAILS the gate instead of shipping quietly. That is
+# a stricter posture than before, not a looser one.
 #
 # The patch version floats deliberately (see the previous python:3.10-alpine3.22 base and
 # the rebuild-picks-it-up posture in PER-15532). Note what that posture costs if nothing
@@ -145,12 +150,15 @@ RUN mkdir -p /app/backup && chmod -R 777 /app/backup
 #      `cache-from: type=gha`, and the cache key is this instruction text plus the parent
 #      layer - so a release cut months later could replay the 2026-08-04 apk layer and
 #      re-ship the exact packages a customer just flagged. release.yml therefore passes
-#      `no-cache-filter: main,opa_build` to force both to re-resolve on every release.
+#      `no-cache-filters: main` to force that stage to re-resolve on every release, and
+#      tests.yml passes the same value so the scanned image matches the published one.
 #   2. A tag that is never rebuilt rots on its own, and no build-time gate can catch that:
 #      the docker-scout gate in tests.yml runs only on pull_request, so it scanned this
 #      image in July and could not possibly have seen CVEs disclosed in September.
-#      Detecting drift therefore requires re-scanning the PUBLISHED tags on a schedule,
-#      which lives in its own workflow rather than here.
+#      Detecting drift therefore REQUIRES re-scanning the PUBLISHED tags on a schedule.
+#      Deliberately phrased as a requirement, not a description: no workflow in this repo
+#      has a `schedule:` trigger, so nothing here does it yet. That is the job of the
+#      companion change tracked under PER-15358.
 #
 # The PDP never uses SQLite, but its FTS5/zipfile CVEs (CVE-2026-11822,
 # CVE-2026-11824, CVE-2025-70873) are still reported against sqlite-libs, which

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,14 +104,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 #                                                             < 3.11.4, so 3.13 is out of it
 # PSF fixed these only on the 3.13/3.14/3.15 branches - there is no 3.10/3.11/3.12 backport -
 # so the vulnerable code really was present in 3.10.20 and an upgrade was the only fix.
-# CVE-2026-15308 (html.parser DoS) is NOT cleared by this bump: it is patched only in
-# 3.15.0b4 and NVD's range is < 3.15.0, so no released Python satisfies it. It is waived in
-# .docker/scout/pdp-v2.vex.json as unreachable (nothing in the image imports html.parser).
+# CVE-2026-15308 (html.parser CPU-exhaustion DoS) is now cleared too: it was waived here as
+# unreachable while it was patched only in 3.15.0b4, but CPython backported the fix and it
+# landed in 3.13.15 (also 3.14.7). The base tag floats, so the current build resolves
+# 3.13.15 and the waiver has been REMOVED from .docker/scout/pdp-v2.vex.json (v4 -> v5).
+# Do not drop below 3.13.15 - that is the floor for every fix named above.
 #
 # The patch version floats deliberately (see the previous python:3.10-alpine3.22 base and
-# the rebuild-picks-it-up posture in PER-15532): when 3.13.15 ships it will clear
-# CVE-2026-15308 automatically and that waiver can then be dropped. Do not drop below
-# 3.13.14 - that is the floor for the fixes above.
+# the rebuild-picks-it-up posture in PER-15532). Note what that posture costs if nothing
+# ever rebuilds: see the apk note below.
 #
 # Python 3.10 also reaches end of life in October 2026, so this move was due regardless.
 FROM python:3.13-alpine3.23 AS main
@@ -128,6 +129,28 @@ RUN mkdir -p /app/backup && chmod -R 777 /app/backup
 # Install runtime libraries and remove sqlite-libs.
 # Build deps (build-base, *-dev) are installed and removed in the pip install
 # layer to avoid persisting binutils CVEs (CVE-2025-69649, CVE-2025-69650).
+#
+# `apk upgrade` here is the ONLY thing that keeps the OS package set current, and it is
+# only as fresh as the build that ran it. permitio/pdp-v2:0.9.14 was built 2026-08-04 and
+# pinned libcrypto3/libssl3 3.5.7-r0 + libuuid 2.41.4-r0 at that moment. Alpine 3.23 later
+# published openssl 3.5.8-r0 and util-linux 2.41.6-r1, so by 2026-09-09 a customer CPE scan
+# of the UNCHANGED published tag reported 12 CVEs / 21 findings - nine OpenSSL
+# (CVE-2026-14456, CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072,
+# CVE-2026-63073, CVE-2026-63075, CVE-2026-63076, CVE-2026-75803) and three util-linux.
+# Not one of them was a source defect: this Dockerfile was already correct, and a rebuild
+# with no edits produces 0 findings. The image was simply never rebuilt. See PER-15358.
+#
+# Two consequences, both load-bearing:
+#   1. Release builds MUST NOT serve this layer from cache. release.yml uses
+#      `cache-from: type=gha`, and the cache key is this instruction text plus the parent
+#      layer - so a release cut months later could replay the 2026-08-04 apk layer and
+#      re-ship the exact packages a customer just flagged. release.yml therefore passes
+#      `no-cache-filter: main,opa_build` to force both to re-resolve on every release.
+#   2. A tag that is never rebuilt rots on its own, and no build-time gate can catch that:
+#      the docker-scout gate in tests.yml runs only on pull_request, so it scanned this
+#      image in July and could not possibly have seen CVEs disclosed in September.
+#      Detecting drift therefore requires re-scanning the PUBLISHED tags on a schedule,
+#      which lives in its own workflow rather than here.
 #
 # The PDP never uses SQLite, but its FTS5/zipfile CVEs (CVE-2026-11822,
 # CVE-2026-11824, CVE-2025-70873) are still reported against sqlite-libs, which

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,11 +86,30 @@ websockets==17.0
 # CVE-2026-78677, and 3.1.58 closes CVE-2026-76218 / CVE-2026-76219 / CVE-2026-76220 /
 # CVE-2026-76222 + GHSA-jm78-9fvv-mhgr (all HIGH) - seven advisories cleared by this floor.
 #
-# A rebuild alone would have picked up a fixed GitPython by chance, since the constraint was
-# open. That is exactly the failure mode the `websockets` note above describes, so the floor
-# is stated here to make the fix resolver-enforced rather than incidental. The <4 cap matches
-# opal-common's own bound and keeps a major out of a build that has no lockfile. Drop this
-# pin only once opal-common itself floors gitpython >= 3.1.59. See PER-15358.
+# BE PRECISE ABOUT WHAT THIS LINE DOES, because it is easy to over-read: it changes no
+# resolution on any current build path. opal-common's `gitpython<4,>=3.1.32` is the only
+# other bound, nothing else constrains the package, and pip prefers the newest satisfying
+# version - so a fresh resolve lands on 3.1.62 with or without this line. A verification
+# build of the full image confirms exactly that. What actually cleared the CVE from the
+# image was the REBUILD; this line did not.
+#
+# Its job is to be a tripwire, not a fix. A floor only bites when something pushes the
+# resolver below it, and that is a real future: a narrower opal-common bound, a new
+# transitive cap, or the lockfile this build still lacks pinning an older version. Without
+# the floor any of those silently reintroduces a CVSS 9.8 RCE and the only thing standing
+# between it and a release is a scanner noticing. With it, the resolve fails loudly.
+#
+# Deliberately a floor and NOT an exact pin, unlike `websockets`/`ddtrace`/`starlette`
+# above. Those are pinned for reasons that do not apply here - to keep a VEX waiver PURL
+# bound to a known version, or to stop an unvalidated major landing on the OPAL pub/sub
+# path. GitPython has no waiver, sits on no hot path, and is a TRANSITIVE dependency:
+# pinning it exactly would make this repo the owner of an upstream's upgrade cadence for
+# no security gain. Keeping `<4` is not redundancy for its own sake either - it is our own
+# bound, so it still holds if opal-common ever relaxes to allow a 4.x major.
+#
+# The real structural fix is a lockfile, which would make this whole transitive tree
+# explicit and reproducible; see docs/image-vulnerability-management.md. Drop this floor
+# once opal-common itself floors gitpython >= 3.1.59. See PER-15358.
 GitPython>=3.1.59,<4
 opal-common==0.9.6
 opal-client==0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,5 +76,21 @@ starlette==0.50.0
 # pdp-tester run on the result - do not let a rebuild choose a major on its own. See
 # PER-15358.
 websockets==17.0
+# GitPython is a TRANSITIVE dependency of opal-common (`gitpython<4,>=3.1.32`) and nothing
+# else bounds it, so with no lockfile the image build resolved whatever was current at build
+# time. permitio/pdp-v2:0.9.14 (built 2026-08-04) therefore shipped 3.1.57, which carries
+# CVE-2026-78676 - a CRITICAL (CVSS 3.1 9.8 / CVSS 4.0 9.3) argument-injection RCE: unsafe
+# re-serialization of a multi-line git-config value promotes a dormant quoted value into a
+# live directive such as core.hooksPath, giving arbitrary code execution through git's hook
+# mechanism on any unrelated GitConfigParser write. 3.1.59 also closes CVE-2026-78675 and
+# CVE-2026-78677, and 3.1.58 closes CVE-2026-76218 / CVE-2026-76219 / CVE-2026-76220 /
+# CVE-2026-76222 + GHSA-jm78-9fvv-mhgr (all HIGH) - seven advisories cleared by this floor.
+#
+# A rebuild alone would have picked up a fixed GitPython by chance, since the constraint was
+# open. That is exactly the failure mode the `websockets` note above describes, so the floor
+# is stated here to make the fix resolver-enforced rather than incidental. The <4 cap matches
+# opal-common's own bound and keeps a major out of a build that has no lockfile. Drop this
+# pin only once opal-common itself floors gitpython >= 3.1.59. See PER-15358.
+GitPython>=3.1.59,<4
 opal-common==0.9.6
 opal-client==0.9.6


### PR DESCRIPTION
Linear: [PER-15886](https://linear.app/permit/issue/PER-15886) · umbrella [PER-15358](https://linear.app/permit/issue/PER-15358)

## Customer report

> We are planning to go into production with the newest pdp-v2 version. Our internal scanning found that the latest docker version 0.9.14 you offer on docker hub contains 2 critical vulnerabilities. Could you provide us an image where these OS vulnerabilities are fixed?

Their scan of `permitio/pdp-v2:0.9.14`: **21 findings / 12 unique CVEs, 100% OS packages, 2 CRITICAL + 10 HIGH.**

## Is it real? Yes — but it is base-image drift, not a source defect

I scanned the actual published manifest (both arches, digest `sha256:f3031d83…`, built **2026-08-04**):

| | `0.9.14` as published | after a rebuild with **no source change** |
|---|---|---|
| `libcrypto3` / `libssl3` | `3.5.7-r0` | `3.5.8-r0` |
| `libuuid` | `2.41.4-r0` | `2.41.6-r1` |
| CPython | `3.13.14` | `3.13.15` |
| trivy OS CRITICAL/HIGH | **8** | **0** |

Alpine 3.23 published `openssl 3.5.8-r0` and `util-linux 2.41.6-r1` *after* 0.9.14 was built. The Dockerfile already does `apk update && apk upgrade` and already floats its base tag — it was correct. **The image was simply never rebuilt.** Nothing in the customer's OS list required a Dockerfile fix.

All nine OpenSSL CVEs (`CVE-2026-14456`, `-14457`, `-18798`, `-54874`, `-63072`, `-63073`, `-63075`, `-63076`, `-75803`) are fixed in **OpenSSL 3.5.8**; the three util-linux ones in **2.41.6**.

### The two "CRITICAL"s are not critical

Per [OpenSSL's own advisory page](https://openssl-library.org/news/vulnerabilities/), of the nine: **six are Low, three are Moderate, none is Critical.** Both CVEs the customer's scanner escalated to CRITICAL are OpenSSL-rated **Low**:

- **CVE-2026-63073** — untrusted CMP sender DN used as a format string. Needs the PDP to act as a **CMP client**. It does not. ([Red Hat also rates Low](https://access.redhat.com/security/cve/cve-2026-63073))
- **CVE-2026-75803** — AEAD tag not verified on *empty* ciphertext when finalized via raw `EVP_Cipher()`. Needs direct `EVP_Cipher()` calls on ChaCha20-Poly1305/AES-OCB. Python's `ssl`/`hashlib` do not do this.

Also worth noting: the six `libuuid` findings are flagged against the **util-linux source package**, but every one is in `mount`/`umount`/`nsenter` — binaries that are **not installed** in this image. `libuuid` is UUID generation only. Cleared anyway by the version bump.

## What I did find that the customer did NOT report

Their scan was OS-only. A library scan surfaced a **materially worse** issue:

> **`GitPython 3.1.57` → [CVE-2026-78676](https://advisories.gitlab.com/pypi/gitpython/CVE-2026-78676/), a genuine CRITICAL (CVSS 3.1 **9.8** / CVSS 4.0 9.3): argument-injection RCE.** Unsafe re-serialization of a multi-line git-config value promotes a dormant quoted value into a live directive such as `core.hooksPath`, giving arbitrary code execution via git hooks on any unrelated `GitConfigParser` write.

`GitPython` is transitive via `opal-common` (`gitpython<4,>=3.1.32`) and **nothing else bounded it**, so the lockfile-less build took whatever was current. A rebuild would have fixed this only *by luck*. Now floored explicitly. `3.1.59` also closes `CVE-2026-78675`/`-78677`, and `3.1.58` closes `CVE-2026-76218`/`-76219`/`-76220`/`-76222` + `GHSA-jm78-9fvv-mhgr` — **seven advisories** cleared by one floor.

## Changes

1. **`requirements.txt`** — floor `GitPython>=3.1.59,<4`. Clears 1 CRITICAL + 6 HIGH. `<4` matches opal-common's own cap.
2. **`.github/workflows/release.yml`** + **`tests.yml`** — `no-cache-filters: main` on all three build steps. **This is the load-bearing fix.** The GHA cache key is instruction text + parent layer, so a release cut weeks later would happily replay the 2026-08-04 `apk upgrade` / `pip install` layers and **re-ship the exact packages the customer just flagged**. *(Originally written here as `no-cache-filter: main,opa_build` — round 1 corrected the spelling, which was making it inert, and dropped `opa_build`, which already re-executes. Round 3 corrected the claim that the Rust stages "cache normally": on run 34858998837 only `rust_chef` cached and `cargo chef cook` ran 404.6s.)*
3. **`.docker/scout/pdp-v2.vex.json`** v4 → v5 — drop the `CVE-2026-15308` waiver. CPython backported the `html.parser` fix into **3.13.15**, which the floating base tag now resolves. The waiver's own text said to remove it at exactly this point.
4. **`Dockerfile`** — record why a correct Dockerfile still shipped stale packages, so the next person does not go looking for a source bug.

## Verification

Built the exact base + `apk` + `pip` layers with `--no-cache`:

```
libcrypto3 3.5.8-r0   libssl3 3.5.8-r0   libuuid 2.41.6-r1
Python 3.13.15        GitPython 3.1.62   cryptography 50.0.1

trivy --severity CRITICAL,HIGH --pkg-types os,library
  → 12 customer CVEs: 0 remaining
  → GitPython CRITICAL: cleared
```

3 HIGHs remain, all **pre-existing and already VEX-waived** as unreachable behind OPAL's dependency caps: `starlette CVE-2026-48818`/`-54283`, `ddtrace CVE-2026-50271`. No change in this PR affects them.

## To deliver to the customer

Merging is not enough — **a release must be cut** so a new image is actually published. Recommend `0.9.15` (`v0.9.15-rc.1` already exists as a tag). Until a rebuild happens, `0.9.14` on Docker Hub keeps reporting these findings.

## Review round 1 — @zeevmoney (all 7 threads resolved, `0d28883`)

A strong review that caught a change of mine doing **nothing at all**. Every finding was verified independently before I changed anything.

| Finding | Outcome |
| --- | --- |
| **HIGH** `no-cache-filter` is not a valid input | **Fixed.** Checked `action.yml` at v5.4.0 *and* v6.9.0 — only `no-cache-filters` exists; the singular is the buildx CLI flag. The input was being dropped, so this PR's "load-bearing" fix was inert and the stale-layer replay was still live. |
| **HIGH** spelling fix alone decouples tested from published | **Fixed together.** `tests.yml`'s build now passes the same `no-cache-filters: main`. Cuts both ways: otherwise the gate could pass on cached packages the release won't ship, or fail on packages it would never contain. |
| **HIGH** GitPython floor changes no resolution | **Comment rewritten.** Confirmed inert — my verification build resolved 3.1.62 *with* the floor. The rebuild is what cleared the CVE. Floor kept as a tripwire for a future downward push, with the reasoning (and why a floor, not an exact pin) written down. |
| **MED** Rust-caching claim inaccurate | **Fixed**, and dropped `opa_build` from the filter: `COPY custom* /custom` + `custom/` absent from `.dockerignore` + tarball regenerated every run means that stage already re-executes. `Cargo.lock` deliberately not touched — real gap, wider blast radius. |
| **MED** VEX products bound to `@next` | ~~No gap, now documented.~~ **Wrong — overturned in round 2.** The Trivy/`.trivyignore.yaml` published-tag scan I cited does not exist in this repo. Since that phantom *was* the argument, the conclusion inverts: the published tags are matched by no waiver mechanism at all. Now written as a gap. |
| **MED** 3.13.15 floor unenforced | ~~Removing the waiver *is* the enforcement.~~ **My pushback was wrong — Zeev was right.** Scout never reports the interpreter, the gate is `pull_request`-only, and the removed waiver bound `pkg:generic/python`, a PURL Scout does not emit. Fixed properly in round 3: the build now checks the interpreter itself. |
| **MED** present tense for a nonexistent workflow | **Fixed.** Reworded as a requirement; also fixed the same plural bug copied into that comment. |

His two other out-of-diff points are handled too: the PR-only scan gate in **#338**, and the `CLONE_REPO_TOKEN` exposure in **#339** (verified reproducible — with only `.git/`, a nested `.git/config` really does reach the image).

## Review round 2 — @zeevmoney (`b3e85f7`)

On the delta `7fef179..ee023e6`. The three round-1 fixes were accepted, including two pushbacks Zeev withdrew (the `GitPython` floor over an exact pin, and dropping `opa_build` from the filter). He also verified the cache filter empirically rather than by reading it — `CACHED` → `DONE 5.5s` on the identical base digest, a measured cost of ~6s.

This round was almost entirely about the new prose: ~50 of 87 changed lines were comments asserting security properties. Two of them asserted properties that do not hold. **Every finding was verified independently before anything changed, and all six held.**

| Finding | Verified how | Outcome |
| --- | --- | --- |
| **HIGH** "Go 1.26 is still unreleased" is false — and it was the stated removal gate for two waivers | [go.dev release history](https://go.dev/doc/devel/release): 1.26.0 **2026-02-10**, 1.26.8 **2026-09-01**, 1.27.0 **2026-08-19**. Contradicted in-repo too: #334 pins `golang:1.26-bookworm` | **Fixed** in `tests.yml` and both VEX impact statements (v7 → **v8**). Removal gates now name a local, closable condition. The same claim in this PR body is corrected above |
| **HIGH** "removing the waiver IS the enforcement" does not hold | Three independent checks, all confirming: `tests.yml:198` is still `pull_request`-only; run 34620527942's unfiltered report is 15 findings across 6 packages with **no CPython entry**; the removed waiver bound `pkg:generic/python`, a PURL Scout never emits — so it was suppressing nothing | **Fixed, and made real.** Rather than only correcting the prose, the `apk` layer now asserts `sys.version_info >= (3,13,15)` — folded into the existing RUN so it costs no layer, placed after the sqlite surgery so it also proves the interpreter survived, and it runs on **every** build path including releases |
| **MED** the `@next` scope argument rests on machinery that does not exist | `grep -rni trivy` returns exactly the two comment lines this PR added; no `.trivyignore*`; no `schedule:`/`cron:` in any workflow | **Fixed, and the conclusion inverted.** The phantom *was* the argument, so removing it flips "correct because" into an open gap: published tags are matched by no waiver mechanism at all. `tests.yml:82` fixed the same way |
| **MED** `docs/image-vulnerability-management.md` does not exist | `git ls-files '*.md'` → three files, no `docs/` directory | **Fixed.** Cites the tracker, and names the absence out loud — the treatment `Dockerfile:158-161` already got right |
| **MED** the tripwire paragraph's lockfile scenario runs backwards | Correct: a lock is what gets installed, so the floor is never consulted | **Fixed**, plus loudness made conditional on the capping package being exact-pinned. On transitivity I agreed with the point but **not the wording** — `ddtrace` *is* imported first-party (`horizon/pdp.py:321`), so "all four are transitive" would swap one unverifiable claim for another. Cost of drift is the separator. Also stopped implying CI evidence where the verification was a local `--no-cache` build |
| **MED** "the scanned image matches the published one" overstates it | `tests.yml:77` amd64-only vs `release.yml:62/:95` amd64+arm64; scan never runs on the release path | **Fixed.** The guarantee is that neither image is built on a stale package set — explicitly *not* that they match |

**Merge order with #335:** #337 goes first; #335 then rebases to keep this branch's seven statements and add `CVE-2026-54282` on top as **v9** (not v8 — correcting both `x/crypto` impact statements bumped this branch to v8).

Still open and unchanged from round 1, both out of diff: `timeout-minutes` on the two image-building jobs, and `actionlint` in `.pre-commit-config.yaml` — which would have caught the original `no-cache-filter` input-name bug in under a second. Both belong in #338 with the other CI-hygiene work.

## Review round 3 — automated multi-agent pass (`85e5c59`)

Five specialist agents (code review, security audit, architecture, backend/runtime, vulnerability scanning) plus an independent pass over the branch at `b3e85f7`. Of 25 specific factual claims tested, **24 held and one did not**. Every finding below was re-verified by hand; three agent claims were dropped as overstated.

**Fixed in `85e5c59`:**

| Finding | Outcome |
| --- | --- |
| **HIGH** The 3.13.15 check could not detect a broken interpreter | **Fixed.** `sys` is a builtin, so `import sys` loads no extension modules — a version-only check passes on an interpreter whose entire `lib-dynload` is unresolvable, which is what the `.python-rundeps` surgery produces if the `so:` list comes back short. It now imports `ssl/hashlib/zlib/lzma/bz2/ctypes/pyexpat/decimal` first, and uses `sys.exit` rather than `assert` (which `-O` strips). **I had claimed the opposite in a review thread** and have corrected it there. |
| **MED** Wrong OpenVEX justification on both x/crypto waivers | **Fixed.** `vulnerable_code_not_in_execute_path` asserts the component ships and is merely uncalled; the impact statements argue the stronger, provable claim — excluded at link time. Now `vulnerable_code_not_present`. The four starlette waivers keep the old label, which is correct for them. v8 → **v9**. |
| **MED** `release.yml` named the wrong Rust stage, in both directions | **Fixed.** Run 34858998837: exactly three vertices cached, all `rust_chef`; `cargo chef cook` was the longest step at 404.6s. The stage that *does* cache runs `apk add musl-dev openssl-dev zig …` — a package-resolving layer outside the filter, previously unmentioned. |
| **MED** `<4` does not cap GitPython drift to a patch | **Fixed.** It admits 3.2.0; the cap is a major. Verified with `packaging`. Conclusion unchanged, premise now true. |
| **MED** `Dockerfile:57` cited from three places across two files | **Fixed.** #334 moves that stage and `git merge-tree` merges **clean**, so all three assertions would go false silently. They name the stage now. |
| **MED** Stale VEX `timestamp`; **LOW** "seven advisories" is eight; **LOW** `tests.yml` said an undeclared input is "silently dropped" | **All fixed.** Actions emits an `Unexpected input(s)` annotation — the wrong wording was the one claiming no signal exists. |

**Not fixed here — these change security posture or other PRs, and want a decision:**

- **HIGH — the waiver evidence covers a third CVE it does not waive.** Per `vuln.go.dev`, all three live in the same package: `GO-2026-6303` (CVE-2026-56854), `GO-2026-6354` (CVE-2026-78662), `GO-2026-6355` (CVE-2026-56855) → `golang.org/x/crypto/ssh`. The waivers say that package is not linked; the same file says permit-opa#49 must *fix* CVE-2026-56854. Both cannot be true. Waiving it on the same evidence takes the gate from 3 HIGH to 2 — **not** to green, since the two grpc CVEs are in genuinely linked code.
- **HIGH — no release has ever been scanned.** Verified on the run that published this very image: release run 30900950607 (`v0.9.14`) shows `skipped  pdp-tests / docker-scout` alongside `success  build-and-push-pdp`. That is the root cause of the customer report. The ~4-line fix lives in #338, which is *based on this branch*.
- **HIGH — the waivers fail open.** Both workflows clone `permitio/permit-opa` at `ref: main` with no pin, and Scout suppresses on PURL, never on whether `ssh` is linked. If permit-opa ever links it, the waiver keeps suppressing a now-reachable DoS with no signal in either repo.
- **MED** — the Rust binary (PID 1) has no tracked `Cargo.lock`, no `--locked`, no `cargo audit`, and Scout reports zero cargo PURLs; **MED** — the SARIF uploaded to code scanning has no VEX applied, so all 15 findings including the 7 waived ones land in the Security tab; **MED** — arm64 is built only by the job that publishes it and is scanned by nothing; **MED** — CVE-2026-48710 is a **CISA KEV** entry (added 2026-09-02, due 2026-09-16) and that fact is recorded nowhere.

## Review round 4 — @zeevmoney, **approved** (`9676cfc`)

Approved with no CRITICAL or HIGH, on the delta `ee023e6..85e5c59`. Both round-2 HIGHs confirmed resolved. Seven non-blocking findings remain, **two of them established by executing rather than reading**, and both of those land on the control I added in round 3. All seven are fixed.

| Finding | Outcome |
| --- | --- |
| **MED** `decimal` and `hashlib` cannot detect a missing `.so` | **Fixed — the sharpest catch of four rounds.** Both fall back silently to pure Python, so two of my eight imports detected nothing. Reproduced by blocking `_decimal`/`_hashlib` behind a `meta_path` finder: the verbatim old line **exited 0**. Now imports the underscore C extensions directly. *Deviation:* I dropped `_gdbm`/`readline`/`_curses` from the suggested list — `_gdbm` is absent from this machine's CPython 3.13, and all three guard libs the PDP never uses, so they'd add no detection and a standing false-failure risk. |
| **MED** `pkg:generic/python` **is** a PURL Scout emits | **Fixed, and my reasoning was invalid.** I inferred it from the scan *findings* list, which only shows packages that have findings and says nothing about what the SBOM indexes. Reason (c) dropped; reason (a) narrowed to what `tests.yml` already said correctly; the plain true reason — 3.13.15 carries the fix — now stated. |
| **MED** The cache measurement doesn't transplant | **Fixed.** Run 34858998837 is `PDP CI Tests` / `pull_request` / `--platform linux/amd64`, quoted on a two-platform release step. The 404.6s figure carries over; the "longest step" *ranking* cannot. Also: `rust_chef` cached **three of four** — `#18 rustup target add` re-ran at 23.3s. |
| **LOW** The floor passed 3.14.0–3.14.6 | **Fixed.** `(3,14,0) >= (3,13,15)` is `True`, and those are exactly the versions lacking the backport. Now branch-aware: `{13: (3,13,15), 14: (3,14,7)}.get(v[1], (3,15,0))`, tested across eight versions. |
| **LOW** Both GitPython counts wrong | **Fixed from source.** `GHSA-jm78-9fvv-mhgr` **is** `CVE-2026-76221` (OSV aliases), so by GHSA id the 76218–76222 run read as having a gap. The move clears **eleven** distinct CVEs, eight HIGH-or-above. PyPI says **nine** releases in that window, not eight. |
| **LOW** `openssl-dev` / `OPENSSL_DIR` are dead config | **Named as dead and tracked**, not removed — editing the Rust builder stage on a branch this deep risks a broken build for a cosmetic win. Happy to do it as its own PR. |
| **LOW** VEX v9 vs #335's v5 | **Merge order recorded below**; version is now **10**, which is what a union resolution needs anyway. |

**Carried forward and now fixed:** the `CVE-2026-48710` waiver claimed the app "registers no `add_middleware`/`BaseHTTPMiddleware`". That is false — `horizon/pdp.py` adopts OPAL's app and `opal_client/client.py` reaches `opal_common/middleware.py:77`, which registers `CORSMiddleware`. **The conclusion survives**: `starlette/middleware/cors.py` reads no `path`, no `url` and never constructs a `Request`, dispatching only on `Origin` and `scope['method']`, so it cannot observe the divergence this CVE induces. Premise now stated accurately. (I repeated this same false claim in my own round-3 review — it was wrong there too.)

### ⚠️ Merge order with #335

**#337 merges first; #335 rebases onto it.** The two diverge structurally — this PR has 7 statements at v10 including both x/crypto waivers; #335 has 6 at v5 including `CVE-2026-54282`, which exists nowhere else. A side-pick resolution loses real waivers in either direction. Rebasing #335 onto a merged #337 makes it a one-statement addition instead of a seven-vs-six conflict. #335 should **not** inherit the unversioned `pkg:docker/permitio/pdp-v2` product `@id` on a superset assumption without testing it against a real scan — `824c783` exists because Scout matches on the full PURL string.

## Also in this PR: the two x/crypto CVEs Go 1.25 cannot clear

The `docker-scout` check on this PR fails on **5 HIGH that do not come from this repo**. `/app/bin/opa` is compiled from `permit-opa`, so its Go module CVEs land in our scans. **That gate has been red since 2026-09-06** — #333 and #336 both went red on it and were merged anyway — so this is pre-existing drift, not a regression here.

Split by what is actually fixable:

- **permitio/permit-opa#49** bumps `grpc` 1.82.1 → **1.83.2** and `x/crypto` 0.53.0 → **0.55.0**, clearing 3 of the 5. (Note: 1.83.1 is *not* enough for CVE-2026-84445 — its range covers `>=1.83.0 <1.83.2`. Only caught by scanning the rebuilt binary.)
- **CVE-2026-78662** and **CVE-2026-56855** are fixed only in `x/crypto >= 0.56.0`, whose go.mod declares `go 1.26.0`. ~~Go 1.26 is not released~~ — **corrected in round 2: Go 1.26.0 shipped 2026-02-10, 1.26.8 is current, and `golang:1.26-bookworm` exists.** The blocker is local, not upstream: `Dockerfile:57` is still `golang:1.25-bookworm` and permit-opa's go.mod is `go 1.25.0`, and the official golang images set `GOTOOLCHAIN=local` so the toolchain cannot move implicitly. Gated on #334 plus a matching permit-opa change.

Those two are waived in `vex.json` (now **v8**) on **evidence, not assertion**: both live in `golang.org/x/crypto/ssh`, and `go list -deps ./cmd/opa` in permit-opa shows that package is **not linked into the binary at all** — only `cryptobyte`, `chacha20(+poly1305)`, `pbkdf2`, `curve25519`, `blake2b`, `salsa20`, `nacl/*`, `hkdf`, `sha3`. The SSH transport is never linked, and the PDP speaks no SSH of its own. Each statement names its removal gate, and after round 2 that gate is a condition someone can actually close: land #334, move permit-opa to `go 1.26.0` + `x/crypto 0.56.0`, delete the statements. Nothing waits on Go.

### ⚠️ The first version of those waivers bound to nothing

Worth flagging since it's a trap anyone can hit. Scout matches VEX `subcomponents` on the **full PURL string**, and it emits Go PURLs **without the conventional `v` prefix**:

```
pkg:golang/golang.org/x/crypto@0.53.0      <- what Scout emits
pkg:golang/golang.org/x/crypto@v0.55.0     <- what I first wrote
```

Two independent mismatches — the `v`, and the version (the build resolves 0.53.0 until permit-opa#49 merges, 0.55.0 after). The waivers suppressed nothing, and would have **kept** suppressing nothing after #49 landed, looking like a Scout bug weeks later.

Diagnosed by reading the gate log rather than guessing: `docker-scout` prints the PURL above each finding, and `pkg:pypi/starlette@0.50.0` / `pkg:pypi/ddtrace@3.19.8` were being suppressed correctly in the *same* run — so the mechanism was fine and my PURL was wrong. (Scout CLI needs a Docker login this environment doesn't have, so this was verified from its output, not a local re-run.)

Fixed by listing **both** versions as subcomponents. Deliberately *not* fixed by dropping `subcomponents`, which [broadens the statement to the whole image](https://docs.docker.com/scout/guides/vex/) — scope is the point of a waiver. Both traps are now recorded in the runbook in #338.

## CI: `docker-scout` is red, and it is supposed to be

Checked the actual run rather than assuming. **Nothing here needs fixing** — the gate is working and reporting real findings with an owner.

```
✓ Loaded 1 VEX document
pkg:golang/google.golang.org/grpc@1.82.1
  ✗ HIGH CVE-2026-84304
  ✗ HIGH CVE-2026-84445
pkg:golang/golang.org/x/crypto@0.53.0
  ✗ HIGH CVE-2026-56854
3 vulnerabilities found in 2 packages
```

**The corrected waivers are confirmed binding** — down from 5 findings to 3, with `CVE-2026-78662` / `CVE-2026-56855` gone. #339 is an accidental control group: it branches off `main`, so it carries no waivers and still reports all **5**. Same image, same scanner, waivers the only difference.

| Branch | Waivers? | Gate reports |
| --- | --- | --- |
| #339 (off `main`) | no | **5** |
| #337 / #338 | yes | **3** |
| after permit-opa#49 | yes | **0** (expected) |

All three remaining are fixed by **permitio/permit-opa#49** (`grpc` → 1.83.2, `x/crypto` → 0.55.0). `tests.yml` clones `permit-opa@main`, so that PR must merge first. Every other job passes, including the full `pdp-tester` e2e.

The other red check, `security/snyk (permit)`, returns `ERROR` on every PR in every permitio repo — a broken integration, not a finding.

## Merge order

`tests.yml` clones `permit-opa@main` at build time, so:

> ⚠️ **This PR cannot go green until permitio/permit-opa#49 merges.** Once it's in, the two grpc CVEs disappear from the build and the two waivers cover the rest.

Verified locally: trivy on the rebuilt OPA binary with grpc 1.83.2 + x/crypto 0.55.0 reports **0 CRITICAL/HIGH**, down from 5. And a **full `pdp-v2` image** built from this branch with permit-opa#49's `custom_opa.tar.gz` scans **0 CRITICAL/HIGH** across OS + Python + Go.

(The other red check, `security/snyk (permit)`, is `ERROR` on every recent PR in this repo — broken integration, not a finding.)

## Follow-up

The root cause is that **nothing re-scans a published tag**. The `docker-scout` gate in `tests.yml` is `if: github.event_name == 'pull_request'`, so it scanned this image in July and could not have seen CVEs disclosed on 2026-09-09 — and because releases arrive as `workflow_call`, it never gated a release at all. **#338** fixes both, adds scheduled re-scanning of published tags, Dependabot, and digest-pinned base images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







