### PR TITLE
fix(ci): keep the permit-opa clone token out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 # Version control
+# `.git/` alone anchors at the context root, so it does NOT exclude a nested checkout's
+# git dir. release.yml/tests.yml clone permitio/permit-opa to ./permit-opa, and its
+# .git/config can carry a credential - which `COPY . .` would then pull into the rust
+# stages, and `cache-to: mode=max` would export to the GHA cache. `**/.git/` closes that
+# regardless of where a checkout lands. See PER-15358.
+**/.git/
 .git/
 .gitignore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
         ref: main
         path: './permit-opa'
         token: ${{ secrets.CLONE_REPO_TOKEN }}
+        # Without this, checkout writes the token into permit-opa/.git/config as an
+        # http.extraheader and leaves it there. Nothing after this step talks to git -
+        # the tarball is built with find/tar - so there is nothing to persist it for.
+        persist-credentials: false
 
     - name: Pre build PDP
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,10 @@ jobs:
           ref: main
           path: './permit-opa'
           token: ${{ secrets.CLONE_REPO_TOKEN }}
+          # Without this, checkout writes the token into permit-opa/.git/config as an
+          # http.extraheader and leaves it there. Nothing after this step talks to git -
+          # the tarball is built with find/tar - so there is nothing to persist it for.
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Linear: [PER-15886](https://linear.app/permit/issue/PER-15886) · umbrella [PER-15358](https://linear.app/permit/issue/PER-15358)

Raised by @zeevmoney while reviewing #337, as pre-existing and deserving its own PR. Confirmed — and it reproduces.

## The path

Both workflows check out `permitio/permit-opa` with `token: ${{ secrets.CLONE_REPO_TOKEN }}` and **no `persist-credentials: false`**, so `actions/checkout` leaves that PAT in `permit-opa/.git/config` as an `http.extraheader`. From there:

1. `.dockerignore` lists `.git/`, which **anchors at the context root** — it does not match a nested checkout's git dir.
2. So `permit-opa/.git/` stays in the build context.
3. `Dockerfile:25` and `:42` do `COPY . .` into `rust_planner` and `rust_builder`.
4. Both workflows use `cache-to: type=gha,mode=max`, which exports **every intermediate stage layer** to the Actions cache.

Net effect: a PAT in a cache that any workflow run in the repo can read.

## Verified, not assumed

`.dockerignore` pattern semantics are easy to get wrong, so I built a context containing both a root and a nested `.git` and built it twice:

| `.dockerignore` | Result |
| --- | --- |
| `.git/` only (as on `main`) | `/ctx/nested/.git/config` **present in the image** |
| `+ **/.git/` | no `.git/config` in the image, app files intact |

## Two changes, belt-and-braces on purpose

They fail independently, so both are worth having:

1. **`persist-credentials: false`** on both `permit-opa` checkouts — stops the token being written down at all. Safe here: nothing after those steps talks to git, the tarball is assembled with `find`/`tar`.
2. **`**/.git/`** in `.dockerignore` — containment, so no future checkout under any path can put a git dir into the context even if someone re-adds a token.

## Scope

Kept to the `permit-opa` checkouts. The repo's own checkouts persist the default `GITHUB_TOKEN` too, but the root `.git/` is already excluded so they don't reach the context — changing those is hygiene with a wider blast radius and doesn't belong in a fix for this.

## ⚠️ Operational follow-up this PR can't do

Existing GHA caches were written under the old behaviour and **may still hold the header**. Merging this only stops *new* caches from carrying it. Recommend:

- **rotate `CLONE_REPO_TOKEN`**
- **purge the Actions cache** for this repo

## CI note

`docker-scout` fails here with **5** findings, where #337/#338 show 3. That difference is expected and not caused by this PR: it branches off `main`, so it does not carry #337's two `x/crypto/ssh` waivers. All 5 live in `permit-opa`'s Go modules and are cleared by permitio/permit-opa#49 (three of them) plus #337's waivers (the other two). Nothing in this PR touches the image contents.

`security/snyk (permit)` returns `ERROR` on every PR in every permitio repo — broken integration, not a finding.

Related: #337, #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

